### PR TITLE
mid3cp: add --merge option. Fixes #277

### DIFF
--- a/docs/man/mid3cp.rst
+++ b/docs/man/mid3cp.rst
@@ -37,6 +37,10 @@ OPTIONS
 --exclude-tag, -x
     Exclude a specific tag from being copied. Can be specified multiple times.
 
+--merge
+    Copy over frames instead of replacing the whole ID3 tag. The tag version
+    of *dest* will be used. In case *dest* has no ID3 tag this option has no
+    effect.
 
 
 AUTHOR

--- a/man/mid3cp.1
+++ b/man/mid3cp.1
@@ -51,6 +51,10 @@ Write ID3v1 tags to the destination file, derived from the ID3v2 tags.
 .TP
 .B \-\-exclude\-tag\fP,\fB  \-x
 Exclude a specific tag from being copied. Can be specified multiple times.
+.TP
+.B \-\-merge
+Copy over frames instead of replacing the whole ID3 tag. The tag version
+of \fIdest\fP will be used.
 .UNINDENT
 .SH AUTHOR
 .sp


### PR DESCRIPTION
Instead of replacing the whole tag this will copy over
frames and potentially replace existing frames.

The id3 version of the target will be used. Excluded frames and
frames not supported by the target version will not be copied.

In case the target has no ID3 tag this option has no effect.