### PR TITLE
Conditionally import mmap. 

### DIFF
--- a/mutagen/_util.py
+++ b/mutagen/_util.py
@@ -16,7 +16,11 @@ import sys
 import struct
 import codecs
 import errno
-import mmap
+
+try:
+    import mmap
+except:
+    pass
 
 from collections import namedtuple
 from contextlib import contextmanager


### PR DESCRIPTION
Hello, 

This pull request fixes a problem in Google App Engine Standard Environment that prevents mutagen from being used there. GAE doesn't have the 'mmap' standard library (because there's no access to real files). However, GAE can use Cloud Storage like a file in Python and mutagen works well. Here's how I use it:

https://github.com/mike-matera/MixPlayer/blob/master/playlist.py

I've also used the MP3 constructor which worked well (but was more than I needed). 

Thanks for the great library. I can now tag cloud files! 
./m