### PR TITLE
Fix tests on big endian architectures

### DIFF
--- a/tests/test__id3frames.py
+++ b/tests/test__id3frames.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import operator
+import sys
 
 from tests import TestCase
 
@@ -1588,8 +1589,12 @@ class TCTOC(TestCase):
                      child_element_ids=[u"ch0"],
                      sub_frames=[TPE2(encoding=3, text=[u"f", u"b"])])
         config = ID3SaveConfig(3, "/")
-        data = (b"foo\x00\x03\x01ch0\x00TPE2\x00\x00\x00\x0b\x00\x00\x01"
-                b"\xff\xfef\x00/\x00b\x00\x00\x00")
+        if sys.byteorder == 'little':
+            data = (b"foo\x00\x03\x01ch0\x00TPE2\x00\x00\x00\x0b\x00\x00\x01"
+                    b"\xff\xfef\x00/\x00b\x00\x00\x00")
+        else:
+            data = (b"foo\x00\x03\x01ch0\x00TPE2\x00\x00\x00\x0b\x00\x00\x01"
+                    b"\xfe\xff\x00f\x00/\x00b\x00\x00")
         self.assertEqual(frame._writeData(config), data)
 
     def test_eq(self):

--- a/tests/test__id3specs.py
+++ b/tests/test__id3specs.py
@@ -338,9 +338,15 @@ class TID3FramesSpec(TestCase):
 
         tags = ID3Tags()
         tags.add(TIT3(encoding=3, text=[u"F", u"B"]))
-        self.assertEqual(spec.write(config, None, tags),
-            b"TIT3" + b"\x00\x00\x00\x0B" + b"\x00\x00" +
-            b"\x01" + b"\xff\xfeF\x00/\x00B\x00\x00\x00")
+        data = spec.write(config, None, tags)
+        if sys.byteorder == 'little':
+            self.assertEqual( data,
+                b"TIT3" + b"\x00\x00\x00\x0B" + b"\x00\x00" +
+                b"\x01" + b"\xff\xfeF\x00/\x00B\x00\x00\x00")
+        else:
+            self.assertEqual( data,
+                b"TIT3" + b"\x00\x00\x00\x0B" + b"\x00\x00" +
+                b"\x01" + b"\xfe\xff\x00F\x00/\x00B\x00\x00")
 
     def test_validate(self):
         header = ID3Header()


### PR DESCRIPTION
I noticed these two tests were failing on BE systems
and fixes were committed to other tests with same symptoms
so I applied the same logic here to fix these.