### PR TITLE
expose 'non-strict' apic frame changes

### DIFF
--- a/mutagen/id3/_tags.py
+++ b/mutagen/id3/_tags.py
@@ -325,18 +325,18 @@ class ID3Tags(DictProxy, Tags):
                     break
                 hash_key = new_hash
 
-    def loaded_frame(self, tag):
+    def loaded_frame(self, tag, strict=True):
         """Deprecated; use the add method."""
 
-        self._add(tag, True)
+        self._add(tag, strict)
 
-    def add(self, frame):
+    def add(self, frame, strict=True):
         """Add a frame to the tag."""
 
         # add = loaded_frame (and vice versa) break applications that
         # expect to be able to override loaded_frame (e.g. Quod Libet),
         # as does making loaded_frame call add.
-        self.loaded_frame(frame)
+        self.loaded_frame(frame, strict)
 
     def __setitem__(self, key, tag):
         if not isinstance(tag, Frame):

--- a/tests/test_id3.py
+++ b/tests/test_id3.py
@@ -202,7 +202,10 @@ class TID3Read(TestCase):
         id3.version = (2, 4)
         pic = PIC(encoding=0, mime="PNG", desc="cover", type=3, data=b"")
         id3.add(pic)
-        self.assertRaises(TypeError, id3.add(pic))
+        id3.add(pic)
+        # pic replaced (NOT added) due to duplicate 'hash' (uses 'type:desc')
+        self.assertEqual(len(id3.getall("APIC")), 1)
+        # disable 'strict' to merge duplicate frame with existing
         id3.add(pic, strict=False)
         self.assertEqual(len(id3.getall("APIC")), 2)
 

--- a/tests/test_id3.py
+++ b/tests/test_id3.py
@@ -147,7 +147,7 @@ class TID3Read(TestCase):
         # sure that old code keeps working (used in quod libet <=3.6)
         class ID3hack(ID3):
             "Override 'correct' behavior with desired behavior"
-            def loaded_frame(self, tag):
+            def loaded_frame(self, tag, strict=True):
                 if tag.HashKey in self:
                     self[tag.HashKey].extend(tag[:])
                 else:
@@ -196,6 +196,15 @@ class TID3Read(TestCase):
         id3.add(PIC(encoding=0, mime="PNG", desc="cover", type=3, data=b""))
         id3.update_to_v24()
         self.failUnlessEqual(id3["APIC:cover"].mime, "image/png")
+
+    def test_multi_pic(self):
+        id3 = ID3()
+        id3.version = (2, 4)
+        pic = PIC(encoding=0, mime="PNG", desc="cover", type=3, data=b"")
+        id3.add(pic)
+        self.assertRaises(TypeError, id3.add(pic))
+        id3.add(pic, strict=False)
+        self.assertEqual(len(id3.getall("APIC")), 2)
 
     def test_lnk(self):
         id3 = ID3()


### PR DESCRIPTION
-expose the existing 'strict' flag for loading APIC frames in the ID3Tag class
-this facilitates pushing multiple frames to a tag which happen to use the same APICType *and* description.
-by default (`strict == True`)this fails, as the sensible assumption is that the frames are the same, however, their content may differ.