### PR TITLE
Be deterministic when saving to file

### DIFF
--- a/mutagen/apev2.py
+++ b/mutagen/apev2.py
@@ -459,7 +459,7 @@ class APEv2(_CIDictProxy, Metadata):
         # "APE tags items should be sorted ascending by size... This is
         # not a MUST, but STRONGLY recommended. Actually the items should
         # be sorted by importance/byte, but this is not feasible."
-        tags.sort(key=lambda tag: (len(tag), tag[8:256 + 8]))
+        tags.sort(key=lambda tag: (len(tag), tag))
         num_tags = len(tags)
         tags = b"".join(tags)
 

--- a/mutagen/apev2.py
+++ b/mutagen/apev2.py
@@ -459,7 +459,7 @@ class APEv2(_CIDictProxy, Metadata):
         # "APE tags items should be sorted ascending by size... This is
         # not a MUST, but STRONGLY recommended. Actually the items should
         # be sorted by importance/byte, but this is not feasible."
-        tags.sort(key=len)
+        tags.sort(key=lambda tag: (len(tag), tag[8:256 + 8]))
         num_tags = len(tags)
         tags = b"".join(tags)
 

--- a/tests/test_apev2.py
+++ b/tests/test_apev2.py
@@ -141,6 +141,15 @@ class TAPEWriter(TestCase):
         tag[u"cba"] = "abc"
         tag.save()
 
+    def test_save_sort_is_deterministic(self):
+        tag = mutagen.apev2.APEv2(SAMPLE + ".new")
+        tag["cba"] = "my cba value"
+        tag["abc"] = "my abc value"
+        tag.save()
+        with open(SAMPLE + ".new", 'rb') as fobj:
+            content = fobj.read()
+            self.assertTrue(content.index(b"abc") < content.index(b"cba"))
+
     def tearDown(self):
         os.unlink(SAMPLE + ".new")
         os.unlink(BROKEN + ".new")


### PR DESCRIPTION
I am using Unison as a backup tool for my music files and every time I update my library's tags with Mutagen some of them are found modified although the audio part and the tags had not been modified. I found out that APEV2 tags are sorted by lengths before saving to file but this is not sufficient. Tags that have the exact same length are saved in random orders because of Python's dictionary implementation. This patch aims to correct this because it adds tags keys to the comparing function and since tag's keys are unique, this ensures that each sorting key is unique too.
The problem is that this is very difficult to test because of its randomness :(