### PR TITLE
mp4: fix 8bit ints getting saved as 16bit (rtng, stik, shwm). Fixes #349

### DIFF
--- a/mutagen/mp4/__init__.py
+++ b/mutagen/mp4/__init__.py
@@ -716,7 +716,8 @@ class MP4Tags(DictProxy, Tags):
                 # by itunes for compatibility.
                 if cdata.int8_min <= v <= cdata.int8_max and min_bytes <= 1:
                     data = cdata.to_int8(v)
-                if cdata.int16_min <= v <= cdata.int16_max and min_bytes <= 2:
+                elif cdata.int16_min <= v <= cdata.int16_max and \
+                        min_bytes <= 2:
                     data = cdata.to_int16_be(v)
                 elif cdata.int32_min <= v <= cdata.int32_max and \
                         min_bytes <= 4:

--- a/tests/test_mp4.py
+++ b/tests/test_mp4.py
@@ -272,6 +272,17 @@ class TMP4Tags(TestCase):
             b"\x00\x00\x00\x15\x00\x00\x00\x00\x00"
         )
 
+    def test_render_integer_min_size(self):
+        render_int = MP4Tags()._MP4Tags__render_integer
+
+        data = render_int('stik', [42], 1)
+        tags = self.wrap_ilst(data)
+        assert tags['stik'] == [42]
+
+        assert len(render_int('stik', [42], 2)) == len(data) + 1
+        assert len(render_int('stik', [42], 4)) == len(data) + 3
+        assert len(render_int('stik', [42], 8)) == len(data) + 7
+
     def test_render_text(self):
         self.failUnlessEqual(
             MP4Tags()._MP4Tags__render_text(


### PR DESCRIPTION
Typo which made it fall through to the next case.