### PR TITLE
pretty print for SYLT

### DIFF
--- a/mutagen/id3/_frames.py
+++ b/mutagen/id3/_frames.py
@@ -1095,13 +1095,18 @@ class SYLT(Frame):
     def HashKey(self):
         return '%s:%s:%s' % (self.FrameID, self.desc, self.lang)
 
+    def _pprint(self):
+        return str(self)
+
     def __eq__(self, other):
         return str(self) == other
 
     __hash__ = Frame.__hash__
 
     def __str__(self):
-        return u"".join(text for (text, time) in self.text)
+        unit = 'fr' if self.format == 1 else 'ms'
+        return u"\n".join("[{0}{1}]: {2}".format(time, unit, text)
+                          for (text, time) in self.text)
 
     def __bytes__(self):
         return text_type(self).encode("utf-8")

--- a/tests/test__id3frames.py
+++ b/tests/test__id3frames.py
@@ -181,7 +181,8 @@ class TVariousFrames(TestCase):
         ],
         [
             'SYLT', (b'\x00eng\x02\x01some lyrics\x00foo\x00\x00\x00\x00\x01'
-                     b'bar\x00\x00\x00\x00\x10'), "foobar", '',
+                     b'bar\x00\x00\x00\x00\x10'),
+            "[1ms]: foo\n[16ms]: bar", '',
             dict(encoding=0, lang='eng', type=1, format=2, desc='some lyrics')
         ],
         ['POSS', b'\x01\x0f', 15, 15, dict(format=1, position=15)],
@@ -330,7 +331,7 @@ class TVariousFrames(TestCase):
         [
             'SLT', (b'\x00eng\x02\x01some lyrics\x00foo\x00\x00\x00\x00\x01bar'
                     b'\x00\x00\x00\x00\x10'),
-            "foobar", '',
+            "[1ms]: foo\n[16ms]: bar", '',
             dict(encoding=0, lang='eng', type=1, format=2, desc='some lyrics')
         ],
         ['TT1', b'\x00ab\x00', 'ab', '', dict(encoding=0)],


### PR DESCRIPTION
This PR adds _pprint() to SYLT class so it doesn't print `[unrepresentable data]` anymore. It also changes __str__ method so that it includes timestamps as well as texts:
```
[1ms]: foo
[16ms]: bar
```