### PR TITLE
Add None default values to all filething args for save/delete(). Fixes #363

### DIFF
--- a/mutagen/_file.py
+++ b/mutagen/_file.py
@@ -97,7 +97,7 @@ class FileType(DictMixin):
             return self.tags.keys()
 
     @loadfile(writable=True)
-    def delete(self, filething):
+    def delete(self, filething=None):
         """delete(filething=None)
 
         Remove tags from a file.
@@ -120,7 +120,7 @@ class FileType(DictMixin):
             return self.tags.delete(filething)
 
     @loadfile(writable=True)
-    def save(self, filething, **kwargs):
+    def save(self, filething=None, **kwargs):
         """save(filething=None, **kwargs)
 
         Save metadata tags.

--- a/mutagen/_tags.py
+++ b/mutagen/_tags.py
@@ -115,7 +115,7 @@ class Metadata(Tags):
         raise NotImplementedError
 
     @loadfile(writable=False)
-    def save(self, filething, **kwargs):
+    def save(self, filething=None, **kwargs):
         """save(filething=None, **kwargs)
 
         Save changes to a file.
@@ -129,7 +129,7 @@ class Metadata(Tags):
         raise NotImplementedError
 
     @loadfile(writable=False)
-    def delete(self, filething):
+    def delete(self, filething=None):
         """delete(filething=None)
 
         Remove tags from a file.

--- a/mutagen/aiff.py
+++ b/mutagen/aiff.py
@@ -271,7 +271,7 @@ class _IFFID3(ID3):
 
     @convert_error(IOError, error)
     @loadfile(writable=True)
-    def save(self, filething, v2_version=4, v23_sep='/', padding=None):
+    def save(self, filething=None, v2_version=4, v23_sep='/', padding=None):
         """Save ID3v2 data to the AIFF file"""
 
         fileobj = filething.fileobj
@@ -299,7 +299,7 @@ class _IFFID3(ID3):
         chunk.write(data)
 
     @loadfile(writable=True)
-    def delete(self, filething):
+    def delete(self, filething=None):
         """Completely removes the ID3 chunk from the AIFF file"""
 
         delete(filething)

--- a/mutagen/apev2.py
+++ b/mutagen/apev2.py
@@ -419,7 +419,7 @@ class APEv2(_CIDictProxy, Metadata):
 
     @convert_error(IOError, error)
     @loadfile(writable=True, create=True)
-    def save(self, filething):
+    def save(self, filething=None):
         """Save changes to a file.
 
         If no filename is given, the one most recently loaded is used.
@@ -481,7 +481,7 @@ class APEv2(_CIDictProxy, Metadata):
 
     @convert_error(IOError, error)
     @loadfile(writable=True)
-    def delete(self, filething):
+    def delete(self, filething=None):
         """Remove tags from a file."""
 
         fileobj = filething.fileobj

--- a/mutagen/asf/__init__.py
+++ b/mutagen/asf/__init__.py
@@ -252,7 +252,7 @@ class ASF(FileType):
 
     @convert_error(IOError, error)
     @loadfile(writable=True)
-    def save(self, filething, padding=None):
+    def save(self, filething=None, padding=None):
         """save(filething=None, padding=None)
 
         Save tag changes back to the loaded file.
@@ -319,7 +319,7 @@ class ASF(FileType):
         raise ASFError
 
     @loadfile(writable=True)
-    def delete(self, filething):
+    def delete(self, filething=None):
         """delete(filething=None)
 
         Args:

--- a/mutagen/dsf.py
+++ b/mutagen/dsf.py
@@ -199,7 +199,7 @@ class _DSFID3(ID3):
 
     @convert_error(IOError, error)
     @loadfile(writable=True)
-    def save(self, filething, v2_version=4, v23_sep='/', padding=None):
+    def save(self, filething=None, v2_version=4, v23_sep='/', padding=None):
         """Save ID3v2 data to the DSF file"""
 
         fileobj = filething.fileobj
@@ -328,7 +328,7 @@ class DSF(FileType):
         self.info = DSFInfo(dsf_file.fmt_chunk)
 
     @loadfile(writable=True)
-    def delete(self, filething):
+    def delete(self, filething=None):
         self.tags = None
         delete(filething)
 

--- a/mutagen/easyid3.py
+++ b/mutagen/easyid3.py
@@ -173,7 +173,8 @@ class EasyID3(DictMixin, Metadata):
                     lambda s, v: setattr(s.__id3, 'load', v))
 
     @loadfile(writable=True, create=True)
-    def save(self, filething, v1=1, v2_version=4, v23_sep='/', padding=None):
+    def save(self, filething=None, v1=1, v2_version=4, v23_sep='/',
+             padding=None):
         """save(filething=None, v1=1, v2_version=4, v23_sep='/', padding=None)
 
         Save changes to a file.

--- a/mutagen/flac.py
+++ b/mutagen/flac.py
@@ -757,7 +757,7 @@ class FLAC(mutagen.FileType):
     add_vorbiscomment = add_tags
 
     @loadfile(writable=True)
-    def delete(self, filething):
+    def delete(self, filething=None):
         """Remove Vorbis comments from a file.
 
         If no filename is given, the one most recently loaded is used.
@@ -829,7 +829,7 @@ class FLAC(mutagen.FileType):
 
     @convert_error(IOError, error)
     @loadfile(writable=True)
-    def save(self, filething, deleteid3=False, padding=None):
+    def save(self, filething=None, deleteid3=False, padding=None):
         """Save metadata blocks to a file.
 
         Args:

--- a/mutagen/id3/_file.py
+++ b/mutagen/id3/_file.py
@@ -218,13 +218,14 @@ class ID3(ID3Tags, mutagen.Metadata):
 
     @convert_error(IOError, error)
     @loadfile(writable=True, create=True)
-    def save(self, filething, v1=1, v2_version=4, v23_sep='/', padding=None):
+    def save(self, filething=None, v1=1, v2_version=4, v23_sep='/',
+             padding=None):
         """save(filething=None, v1=1, v2_version=4, v23_sep='/', padding=None)
 
         Save changes to a file.
 
         Args:
-            filename (fspath):
+            filething (filething):
                 Filename to save the tag to. If no filename is given,
                 the one most recently loaded is used.
             v1 (ID3v1SaveOptions):
@@ -282,7 +283,7 @@ class ID3(ID3Tags, mutagen.Metadata):
             f.truncate()
 
     @loadfile(writable=True)
-    def delete(self, filething, delete_v1=True, delete_v2=True):
+    def delete(self, filething=None, delete_v1=True, delete_v2=True):
         """delete(filething=None, delete_v1=True, delete_v2=True)
 
         Remove tags from a file.

--- a/mutagen/mp4/__init__.py
+++ b/mutagen/mp4/__init__.py
@@ -392,7 +392,7 @@ class MP4Tags(DictProxy, Tags):
 
     @convert_error(IOError, error)
     @loadfile(writable=True)
-    def save(self, filething, padding=None):
+    def save(self, filething=None, padding=None):
 
         values = []
         items = sorted(self.items(), key=lambda kv: _item_sort_key(*kv))

--- a/mutagen/ogg.py
+++ b/mutagen/ogg.py
@@ -535,7 +535,7 @@ class OggFileType(FileType):
             raise self._Error("no appropriate stream found")
 
     @loadfile(writable=True)
-    def delete(self, filething):
+    def delete(self, filething=None):
         """delete(filething=None)
 
         Remove tags from a file.
@@ -567,7 +567,7 @@ class OggFileType(FileType):
         raise self._Error
 
     @loadfile(writable=True)
-    def save(self, filething, padding=None):
+    def save(self, filething=None, padding=None):
         """save(filething=None, padding=None)
 
         Save a tag to a file.


### PR DESCRIPTION
While the decorator make sure that we never get None there, the signature gets
used for API introspection, e.g. pylint. Just add None to all methods where the
decorator allows None in some cases.