### PR TITLE
Fix collections ABCs deprecation warning

### DIFF
--- a/mutagen/_senf/_argv.py
+++ b/mutagen/_senf/_argv.py
@@ -22,7 +22,12 @@
 
 import sys
 import ctypes
-import collections
+try:
+    # Python 3
+    from collections.abc import MutableSequence
+except ImportError:
+    # Python 2.7
+    from collections import MutableSequence
 from functools import total_ordering
 
 from ._compat import PY2, string_types
@@ -57,7 +62,7 @@ def _get_win_argv():
 
 
 @total_ordering
-class Argv(collections.MutableSequence):
+class Argv(MutableSequence):
     """List[`fsnative`]: Like `sys.argv` but contains unicode
     keys and values under Windows + Python 2.
 

--- a/mutagen/_senf/_environ.py
+++ b/mutagen/_senf/_environ.py
@@ -22,7 +22,12 @@
 
 import os
 import ctypes
-import collections
+try:
+    # Python 3
+    from collections.abc import MutableMapping
+except ImportError:
+    # Python 2.7
+    from collections import MutableMapping
 
 from ._compat import text_type, PY2
 from ._fsnative import path2fsn, is_win, _fsn2legacy, fsnative
@@ -130,7 +135,7 @@ def _norm_key(key):
     return key
 
 
-class Environ(collections.MutableMapping):
+class Environ(MutableMapping):
     """Dict[`fsnative`, `fsnative`]: Like `os.environ` but contains unicode
     keys and values under Windows + Python 2.
 

--- a/mutagen/apev2.py
+++ b/mutagen/apev2.py
@@ -32,7 +32,12 @@ __all__ = ["APEv2", "APEv2File", "Open", "delete"]
 
 import sys
 import struct
-from collections import MutableSequence
+try:
+    # Python 3
+    from collections.abc import MutableSequence
+except ImportError:
+    # Python 2.7
+    from collections import MutableSequence
 
 from ._compat import (cBytesIO, PY3, text_type, PY2, reraise, swap_to_string,
                       xrange)


### PR DESCRIPTION
With Python 3.7, I got the following warnings.

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```
This is a pull request to fix the issue. I tested with 3.7.2 and 2.7.15 and confirmed all the tests passed.