### PR TITLE
increase max_syncs to 1024

### DIFF
--- a/mutagen/mp3/__init__.py
+++ b/mutagen/mp3/__init__.py
@@ -357,7 +357,7 @@ class MPEGInfo(StreamInfo):
 
         # find a sync in the first 1024K, give up after some invalid syncs
         max_read = 1024 * 1024
-        max_syncs = 1000
+        max_syncs = 1500
         enough_frames = 4
         min_frames = 2
 


### PR DESCRIPTION
I have absolutely no idea about the meaning of the number, but I have an mp3 file which can only be read if max_syncs >= 1002. The file can be played by many players.