### PR TITLE
flac: support files with multiple VORBIS_COMMENT blocks. Fixes #377

### DIFF
--- a/mutagen/flac.py
+++ b/mutagen/flac.py
@@ -732,7 +732,9 @@ class FLAC(mutagen.FileType):
             if self.tags is None:
                 self.tags = block
             else:
-                raise FLACVorbisError("> 1 Vorbis comment block found")
+                # https://github.com/quodlibet/mutagen/issues/377
+                # Something writes multiple and metaflac doesn't care
+                pass
         elif block.code == CueSheet.code:
             if self.cuesheet is None:
                 self.cuesheet = block
@@ -756,6 +758,7 @@ class FLAC(mutagen.FileType):
 
     add_vorbiscomment = add_tags
 
+    @convert_error(IOError, error)
     @loadfile(writable=True)
     def delete(self, filething=None):
         """Remove Vorbis comments from a file.
@@ -764,11 +767,12 @@ class FLAC(mutagen.FileType):
         """
 
         if self.tags is not None:
-            self.metadata_blocks.remove(self.tags)
-            try:
-                self.save(filething, padding=lambda x: 0)
-            finally:
-                self.metadata_blocks.append(self.tags)
+            temp_blocks = [
+                b for b in self.metadata_blocks if b.code != VCFLACDict.code]
+            self._save(filething, temp_blocks, False, padding=lambda x: 0)
+            self.metadata_blocks[:] = [
+                b for b in self.metadata_blocks
+                if b.code != VCFLACDict.code or b is self.tags]
             self.tags.clear()
 
     vc = property(lambda s: s.tags, doc="Alias for tags; don't use this.")
@@ -840,6 +844,9 @@ class FLAC(mutagen.FileType):
         If no filename is given, the one most recently loaded is used.
         """
 
+        self._save(filething, self.metadata_blocks, deleteid3, padding)
+
+    def _save(self, filething, metadata_blocks, deleteid3, padding):
         f = StrictFileObject(filething.fileobj)
         header = self.__check_header(f, filething.name)
         audio_offset = self.__find_audio_offset(f)
@@ -854,7 +861,7 @@ class FLAC(mutagen.FileType):
         content_size = get_size(f) - audio_offset
         assert content_size >= 0
         data = MetadataBlock._writeblocks(
-            self.metadata_blocks, available, content_size, padding)
+            metadata_blocks, available, content_size, padding)
         data_size = len(data)
 
         resize_bytes(filething.fileobj, available, data_size, header)


### PR DESCRIPTION
While the flac spec states that "There may be only one VORBIS_COMMENT block in a stream"
metaflac and other programs don't fail when they parse such a file and just use the first
block (same for VLC and Totem).

Instead of raising when loading a file with multiple blocks just use the first one for the
tags interface and leave the other blocks as is, including writing it back as is.

The only other change is in delete() where we delete all VORBIS_COMMENT blocks, even the
ones not exposed. This makes sure that reloading a file that had its tags deleted doesn't
exposed the other tag block suddenly.

Fixes #377