### PR TITLE
Rework TYER/TDAT/TIME upgrade to TDRC. Fixes #380

### DIFF
--- a/mutagen/_compat.py
+++ b/mutagen/_compat.py
@@ -16,7 +16,7 @@ if PY2:
     from StringIO import StringIO
     BytesIO = StringIO
     from cStringIO import StringIO as cBytesIO
-    from itertools import izip
+    from itertools import izip, izip_longest
 
     long_ = long
     integer_types = (int, long)
@@ -55,12 +55,14 @@ elif PY3:
     StringIO = StringIO
     from io import BytesIO
     cBytesIO = BytesIO
+    from itertools import zip_longest
 
     long_ = int
     integer_types = (int,)
     string_types = (str,)
     text_type = str
 
+    izip_longest = zip_longest
     izip = zip
     xrange = range
     cmp = lambda a, b: (a > b) - (a < b)

--- a/tests/test_id3.py
+++ b/tests/test_id3.py
@@ -326,6 +326,16 @@ class TID3Read(TestCase):
         id3.update_to_v24()
         self.failUnlessEqual(id3["TDRC"], "2006-03-06 11:27:00")
 
+    def test_multiple_tyer_tdat_time(self):
+        id3 = ID3()
+        id3.version = (2, 3)
+        id3.add(TYER(text=['2000', '2001', '2002', '19xx', 'foo']))
+        id3.add(TDAT(text=['0102', '0304', '1111bar']))
+        id3.add(TIME(text=['1220', '1111quux', '1111']))
+        id3.update_to_v24()
+        assert [str(t) for t in id3['TDRC']] == \
+            ['2000-02-01 12:20:00', '2001-04-03', '2002']
+
     def test_tory(self):
         id3 = ID3()
         id3.version = (2, 3)


### PR DESCRIPTION
Be a bit stricter in what we allow to end up in the final timestamp
and handle multiple sets of TYER/TDAT/TIME correctly.