### PR TITLE
MP4: Add support for iTunes HD Video tag

### DIFF
--- a/mutagen/mp4/__init__.py
+++ b/mutagen/mp4/__init__.py
@@ -311,6 +311,7 @@ class MP4Tags(DictProxy, Tags):
     * '\\xa9mvi' -- Movement Index
     * 'shwm' -- work/movement
     * 'stik' -- Media Kind
+    * 'hdvd' -- HD Video
     * 'rtng' -- Content Rating
     * 'tves' -- TV Episode
     * 'tvsn' -- TV Season
@@ -852,6 +853,7 @@ class MP4Tags(DictProxy, Tags):
         b"pcst": (__parse_bool, __render_bool),
         b"shwm": (__parse_integer, __render_integer, 1),
         b"stik": (__parse_integer, __render_integer, 1),
+        b"hdvd": (__parse_integer, __render_integer, 1),
         b"rtng": (__parse_integer, __render_integer, 1),
         b"covr": (__parse_cover, __render_cover),
         b"purl": (__parse_text, __render_text),

--- a/tests/test_mp4.py
+++ b/tests/test_mp4.py
@@ -645,8 +645,8 @@ class TMP4Mixin(object):
 
     def test_various_int(self):
         keys = [
-            "stik", "rtng", "plID", "cnID", "geID", "atID", "sfID",
-            "cmID", "akID", "tvsn", "tves",
+            "stik", "hdvd", "rtng", "plID", "cnID", "geID", "atID",
+            "sfID", "cmID", "akID", "tvsn", "tves",
         ]
 
         for key in keys:


### PR DESCRIPTION
The atom is named "hdvd", it's an 8 bit integer where:
0 - SD
1 - 720p
2 - 1080p

iTunes and Apple TV refer to it rather than actual resolution info from the video stream, so it's a helpful tag to have.