### PR TITLE
aiff: renamed sample_size to bits_per_sample

### DIFF
--- a/mutagen/aiff.py
+++ b/mutagen/aiff.py
@@ -224,7 +224,7 @@ class AIFFInfo(StreamInfo):
         bitrate (`int`): audio bitrate, in bits per second
         channels (`int`): The number of audio channels
         sample_rate (`int`): audio sample rate, in Hz
-        sample_size (`int`): The audio sample size
+        bits_per_sample (`int`): The audio sample size
     """
 
     length = 0
@@ -250,7 +250,8 @@ class AIFFInfo(StreamInfo):
         channels, frame_count, sample_size, sample_rate = info
 
         self.sample_rate = int(read_float(sample_rate))
-        self.sample_size = sample_size
+        self.bits_per_sample = sample_size
+        self.sample_size = sample_size  # For backward compatibility
         self.channels = channels
         self.bitrate = channels * sample_size * self.sample_rate
         self.length = frame_count / float(self.sample_rate)

--- a/tests/test_aiff.py
+++ b/tests/test_aiff.py
@@ -60,12 +60,18 @@ class TAIFF(TestCase):
         self.failUnlessEqual(self.aiff_4.info.sample_rate, 8000)
         self.failUnlessEqual(self.aiff_5.info.sample_rate, 8000)
 
+    def test_bits_per_sample(self):
+        self.failUnlessEqual(self.aiff_1.info.bits_per_sample, 16)
+        self.failUnlessEqual(self.aiff_2.info.bits_per_sample, 16)
+        self.failUnlessEqual(self.aiff_3.info.bits_per_sample, 16)
+        self.failUnlessEqual(self.aiff_4.info.bits_per_sample, 16)
+        self.failUnlessEqual(self.aiff_5.info.bits_per_sample, 16)
+
     def test_sample_size(self):
-        self.failUnlessEqual(self.aiff_1.info.sample_size, 16)
-        self.failUnlessEqual(self.aiff_2.info.sample_size, 16)
-        self.failUnlessEqual(self.aiff_3.info.sample_size, 16)
-        self.failUnlessEqual(self.aiff_4.info.sample_size, 16)
-        self.failUnlessEqual(self.aiff_5.info.sample_size, 16)
+        for test in [self.aiff_1, self.aiff_2, self.aiff_3, self.aiff_4,
+                     self.aiff_5]:
+            info = test.info
+            self.failUnlessEqual(info.sample_size, info.bits_per_sample)
 
     def test_notaiff(self):
         self.failUnlessRaises(


### PR DESCRIPTION
This is consistent with other formats. Keep sample_size as an undocumented field for backward compatibility with existing code.

Fixes #402