### PR TITLE
AIFF: Fix handling of padding bytes, safe chunk manipulation

### DIFF
--- a/mutagen/aiff.py
+++ b/mutagen/aiff.py
@@ -130,7 +130,7 @@ class IFFChunk(object):
         # Write the padding bytes
         padding = self.padding()
         if padding:
-            self._fileobj.seek(self.data_offset + self.data_size + 1)
+            self._fileobj.seek(self.data_offset + self.data_size)
             self._fileobj.write(b'\x00' * padding)
 
     def delete(self):

--- a/mutagen/aiff.py
+++ b/mutagen/aiff.py
@@ -139,6 +139,7 @@ class IFFChunk(object):
         delete_bytes(self._fileobj, self.size, self.offset)
         if self.parent_chunk is not None:
             self.parent_chunk._remove_subchunk(self)
+        self._fileobj.flush()
 
     def _update_size(self, size_diff, changed_subchunk=None):
         """Update the size of the chunk"""
@@ -166,6 +167,7 @@ class IFFChunk(object):
                      new_data_size + padding, self.data_offset)
         size_diff = new_data_size - self.data_size
         self._update_size(size_diff)
+        self._fileobj.flush()
 
     def padding(self):
         """Returns the number of padding bytes (0 or 1).
@@ -244,6 +246,7 @@ class FormIFFChunk(IFFChunk):
         if data:
             chunk.write(data)
         self.subchunks().append(chunk)
+        self._fileobj.flush()
         return chunk
 
     def _remove_subchunk(self, chunk):

--- a/tests/test_aiff.py
+++ b/tests/test_aiff.py
@@ -269,12 +269,28 @@ class TIFFFile(TestCase):
         self.failUnlessEqual(new_iff[u'ID3'].data_size, 0)
 
     def test_insert_padded_chunks(self):
-        self.iff_2_tmp.insert_chunk(u'TST1')
-        self.iff_2_tmp[u'TST1'].resize(3)
-        self.failUnlessEqual(1, self.iff_2_tmp[u'TST1'].padding())
-        self.iff_2_tmp.insert_chunk(u'TST2')
-        self.iff_2_tmp[u'TST2'].resize(4)
-        self.failUnlessEqual(0, self.iff_2_tmp[u'TST2'].padding())
+        padded = self.iff_2_tmp.insert_chunk(u'TST1')
+        unpadded = self.iff_2_tmp.insert_chunk(u'TST2')
+        # The second chunk needs no padding
+        unpadded.resize(4)
+        self.failUnlessEqual(4, unpadded.data_size)
+        self.failUnlessEqual(0, unpadded.padding())
+        self.failUnlessEqual(12, unpadded.size)
+        # Resize the first chunk so it needs padding
+        padded.resize(3)
+        self.failUnlessEqual(3, padded.data_size)
+        self.failUnlessEqual(1, padded.padding())
+        self.failUnlessEqual(12, padded.size)
+        self.failUnlessEqual(padded.offset + padded.size, unpadded.offset)
+        # Verify the padding byte gets written correctly
+        self.file_2_tmp.seek(padded.data_offset)
+        self.file_2_tmp.write(b'ABCD')
+        padded.write(b'ABC')
+        self.file_2_tmp.seek(padded.data_offset)
+        self.failUnlessEqual(b'ABC\x00', self.file_2_tmp.read(4))
+        # Verify the second chunk got not overwritten
+        self.file_2_tmp.seek(unpadded.offset)
+        self.failUnlessEqual(b'TST2', self.file_2_tmp.read(4))
 
     def test_delete_padded_chunks(self):
         iff_file = self.iff_2_tmp


### PR DESCRIPTION
This refactors the AIFF code to:

- Fix handling of padding bytes: For chunks with odd data size there must be a padding byte added. This is now consistently handled for all chunk manipulation (resize, insert, delete). Previously this was not handled for all cases, and reading a file which had a ID3 chunk with padding could lead to file corruption since mutagen would write this chunk back with an even size but keep the padding byte.
- The code can now safely support multiple chunk insert / resize / delete operations while keeping the in-memory representation of all offsets and sizes intact. Previously it was not safe to e.g. both insert and delete chunks in a loaded file, since the in-memory stored offsets for chunks were not updated. This lead to file corruption since data was manipulated at the wrong location

See also the same changes for RIFF files in #408