### PR TITLE
Fix an infinite loop in asf object parsing

### DIFF
--- a/mutagen/asf/_objects.py
+++ b/mutagen/asf/_objects.py
@@ -381,6 +381,8 @@ class HeaderExtensionObject(BaseObject):
             obj.parse(asf, data[22 + datapos + 24:22 + datapos + size])
             self.objects.append(obj)
             datapos += size
+            if size < 1:
+                break
 
     def render(self, asf):
         data = bytearray()


### PR DESCRIPTION
The increment of the while loop could be equal to
zero, so we need to bailout if it's the case,
to avoid getting stuck in an infinite loop.