### PR TITLE
Improve a bit the robustness of asf parsing

### DIFF
--- a/mutagen/asf/_objects.py
+++ b/mutagen/asf/_objects.py
@@ -114,7 +114,10 @@ class HeaderObject(BaseObject):
             if len(data) != payload_size:
                 raise ASFHeaderError("truncated")
 
-            obj.parse(asf, data)
+            try:
+                obj.parse(asf, data)
+            except struct.error:
+                raise ASFHeaderError("truncated")
             header.objects.append(obj)
 
         return header
@@ -379,6 +382,8 @@ class HeaderExtensionObject(BaseObject):
         while datapos < datasize:
             guid, size = struct.unpack(
                 "<16sQ", data[22 + datapos:22 + datapos + 24])
+            if size < 1:
+                raise ASFHeaderError("invalid size in header extension")
             obj = BaseObject._get_object(guid)
             obj.parse(asf, data[22 + datapos + 24:22 + datapos + size])
             self.objects.append(obj)


### PR DESCRIPTION
- Guard against an infinite loop
- Wrap a call into a try...catch, since there
  are a lot of manual offset fiddling involving
  struct.unpack in the child functions, resulting
  in a lot of different ways to trigger
  a struct.error