### PR TITLE
Extract common IFF code to separate module.

### DIFF
--- a/mutagen/_iff.py
+++ b/mutagen/_iff.py
@@ -1,0 +1,334 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2014  Evan Purkhiser
+#               2014  Ben Ockmore
+#               2017  Borewit
+#               2019-2020  Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+"""Base classes for various IFF based formats (e.g. AIFF or RIFF)."""
+
+# import struct
+# from struct import pack
+
+from mutagen._util import (
+    MutagenError,
+    delete_bytes,
+    insert_bytes,
+    resize_bytes,
+)
+
+
+class error(MutagenError):
+    pass
+
+
+class InvalidChunk(error):
+    pass
+
+
+class EmptyChunk(InvalidChunk):
+    pass
+
+
+def is_valid_chunk_id(id):
+    """ is_valid_chunk_id(FOURCC)
+
+    Arguments:
+        id (FOURCC)
+    Returns:
+        true if valid; otherwise false
+
+    Check if argument id is valid FOURCC type.
+    """
+
+    assert isinstance(id, str), \
+        'id is of type %s, must be str: %r' % (type(id), id)
+
+    return ((len(id) <= 4) and (min(id) >= u' ') and
+            (max(id) <= u'~'))
+
+
+#  Assert FOURCC formatted valid
+def assert_valid_chunk_id(id):
+    if not is_valid_chunk_id(id):
+        raise ValueError("IFF chunk ID must be four ASCII characters.")
+
+
+class IffChunk(object):
+    """Generic representation of a single IFF chunk.
+
+    IFF chunks always consist of an ID followed by the chunk size. The exact
+    format varies between different IFF based formats, e.g. AIFF uses
+    big-endian while RIFF uses little-endian.
+    """
+
+    # Chunk headers are usually 8 bytes long (4 for ID and 4 for the size)
+    HEADER_SIZE = 8
+
+    @classmethod
+    def parse_header(cls, header):
+        """Read ID and data_size from the given header.
+        Must be implemented in subclasses."""
+        raise error("Not implemented")
+
+    def write_new_header(self, id_, size):
+        """Write the chunk header with id_ and size to the file.
+        Must be implemented in subclasses. The data must be written
+        to the current position in self._fileobj."""
+        raise error("Not implemented")
+
+    def write_size(self):
+        """Write self.data_size to the file.
+        Must be implemented in subclasses. The data must be written
+        to the current position in self._fileobj."""
+        raise error("Not implemented")
+
+    @classmethod
+    def get_class(cls, id):
+        """Returns the class for a new chunk for a given ID.
+        Can be overridden in subclasses to implement specific chunk types."""
+        return cls
+
+    @classmethod
+    def parse(cls, fileobj, parent_chunk=None):
+        header = fileobj.read(cls.HEADER_SIZE)
+        if len(header) < cls.HEADER_SIZE:
+            raise EmptyChunk('Header size < %i' % cls.HEADER_SIZE)
+        id, data_size = cls.parse_header(header)
+        try:
+            id = id.decode('ascii').rstrip()
+        except UnicodeDecodeError as e:
+            raise InvalidChunk(e)
+
+        if not is_valid_chunk_id(id):
+            raise InvalidChunk('Invalid chunk ID %r' % id)
+
+        return cls.get_class(id)(fileobj, id, data_size, parent_chunk)
+
+    def __init__(self, fileobj, id, data_size, parent_chunk):
+        self._fileobj = fileobj
+        self.id = id
+        self.data_size = data_size
+        self.parent_chunk = parent_chunk
+        self.data_offset = fileobj.tell()
+        self.offset = self.data_offset - self.HEADER_SIZE
+        self._calculate_size()
+
+    def __repr__(self):
+        return ("<%s id=%s, offset=%i, size=%i, data_offset=%i, data_size=%i>"
+            % (type(self).__name__, self.id, self.offset, self.size,
+               self.data_offset, self.data_size))
+
+    def read(self):
+        """Read the chunks data"""
+
+        self._fileobj.seek(self.data_offset)
+        return self._fileobj.read(self.data_size)
+
+    def write(self, data):
+        """Write the chunk data"""
+
+        if len(data) > self.data_size:
+            raise ValueError
+
+        self._fileobj.seek(self.data_offset)
+        self._fileobj.write(data)
+        # Write the padding bytes
+        padding = self.padding()
+        if padding:
+            self._fileobj.seek(self.data_offset + self.data_size)
+            self._fileobj.write(b'\x00' * padding)
+
+    def delete(self):
+        """Removes the chunk from the file"""
+
+        delete_bytes(self._fileobj, self.size, self.offset)
+        if self.parent_chunk is not None:
+            self.parent_chunk._remove_subchunk(self)
+        self._fileobj.flush()
+
+    def _update_size(self, size_diff, changed_subchunk=None):
+        """Update the size of the chunk"""
+
+        old_size = self.size
+        self.data_size += size_diff
+        self._fileobj.seek(self.offset + 4)
+        self.write_size()
+        self._calculate_size()
+        if self.parent_chunk is not None:
+            self.parent_chunk._update_size(self.size - old_size, self)
+        if changed_subchunk:
+            self._update_sibling_offsets(
+                changed_subchunk, old_size - self.size)
+
+    def _calculate_size(self):
+        self.size = self.HEADER_SIZE + self.data_size + self.padding()
+        assert self.size % 2 == 0
+
+    def resize(self, new_data_size):
+        """Resize the file and update the chunk sizes"""
+
+        padding = new_data_size % 2
+        resize_bytes(self._fileobj, self.data_size + self.padding(),
+                     new_data_size + padding, self.data_offset)
+        size_diff = new_data_size - self.data_size
+        self._update_size(size_diff)
+        self._fileobj.flush()
+
+    def padding(self):
+        """Returns the number of padding bytes (0 or 1).
+        IFF chunks are required to be a even number in total length. If
+        data_size is odd a padding byte will be added at the end.
+        """
+        return self.data_size % 2
+
+
+class IffContainerChunkMixin():
+    """A IFF chunk containing other chunks.
+
+    A container chunk can have an additional name as the first 4 bytes of the
+    chunk data followed by an arbitrary number of subchunks. The root chunk of
+    the file is always a container chunk (e.g. the AIFF chunk or the FORM chunk
+    for RIFF) but there can be other types of container chunks (e.g. the LIST
+    chunks used in RIFF).
+    """
+
+    def parse_next_subchunk(self):
+        """"""
+        raise error("Not implemented")
+
+    def init_container(self, name_size=4):
+        # Lists can store an additional name identifier before the subchunks
+        self.__name_size = name_size
+        if self.data_size < name_size:
+            raise InvalidChunk(
+                'Container chunk data size < %i' % name_size)
+
+        # Read the container name
+        if name_size > 0:
+            try:
+                self.name = self._fileobj.read(name_size).decode('ascii')
+            except UnicodeDecodeError as e:
+                raise error(e)
+        else:
+            self.name = None
+
+        # Load all IFF subchunks
+        self.__subchunks = []
+
+    def subchunks(self):
+        """Returns a list of all subchunks.
+        The list is lazily loaded on first access.
+        """
+        if not self.__subchunks:
+            next_offset = self.data_offset + self.__name_size
+            while next_offset < self.offset + self.size:
+                self._fileobj.seek(next_offset)
+                try:
+                    chunk = self.parse_next_subchunk()
+                except EmptyChunk:
+                    break
+                except InvalidChunk:
+                    break
+                self.__subchunks.append(chunk)
+
+                # Calculate the location of the next chunk
+                next_offset = chunk.offset + chunk.size
+        return self.__subchunks
+
+    def insert_chunk(self, id_, data=None):
+        """Insert a new chunk at the end of the container chunk"""
+
+        if not is_valid_chunk_id(id_):
+            raise KeyError("Invalid IFF key.")
+
+        next_offset = self.offset + self.size
+        size = self.HEADER_SIZE
+        data_size = 0
+        if data:
+            data_size = len(data)
+            padding = data_size % 2
+            size += data_size + padding
+        insert_bytes(self._fileobj, size, next_offset)
+        self._fileobj.seek(next_offset)
+        self.write_new_header(id_.ljust(4).encode('ascii'), data_size)
+        self._fileobj.seek(next_offset)
+        chunk = self.parse_next_subchunk()
+        self._update_size(chunk.size)
+        if data:
+            chunk.write(data)
+        self.subchunks().append(chunk)
+        self._fileobj.flush()
+        return chunk
+
+    def __contains__(self, id_):
+        """Check if this chunk contains a specific subchunk."""
+        assert_valid_chunk_id(id_)
+        try:
+            self[id_]
+            return True
+        except KeyError:
+            return False
+
+    def __getitem__(self, id_):
+        """Get a subchunk by ID."""
+        assert_valid_chunk_id(id_)
+        found_chunk = None
+        for chunk in self.subchunks():
+            if chunk.id == id_:
+                found_chunk = chunk
+                break
+        else:
+            raise KeyError("No %r chunk found" % id_)
+        return found_chunk
+
+    def __delitem__(self, id_):
+        """Remove a chunk from the IFF file"""
+        assert_valid_chunk_id(id_)
+        self[id_].delete()
+
+    def _remove_subchunk(self, chunk):
+        assert chunk in self.__subchunks
+        self._update_size(-chunk.size, chunk)
+        self.__subchunks.remove(chunk)
+
+    def _update_sibling_offsets(self, changed_subchunk, size_diff):
+        """Update the offsets of subchunks after `changed_subchunk`.
+        """
+        index = self.__subchunks.index(changed_subchunk)
+        sibling_chunks = self.__subchunks[index + 1:len(self.__subchunks)]
+        for sibling in sibling_chunks:
+            sibling.offset -= size_diff
+            sibling.data_offset -= size_diff
+
+
+class IffFile:
+    """Representation of a IFF file"""
+
+    def __init__(self, chunk_cls, fileobj):
+        fileobj.seek(0)
+        self.root = chunk_cls.parse(fileobj)
+
+    def __contains__(self, id_):
+        """Check if the IFF file contains a specific chunk"""
+        return id_ in self.root
+
+    def __getitem__(self, id_):
+        """Get a chunk from the IFF file"""
+        return self.root[id_]
+
+    def __delitem__(self, id_):
+        """Remove a chunk from the IFF file"""
+        self.delete_chunk(id_)
+
+    def delete_chunk(self, id_):
+        """Remove a chunk from the IFF file"""
+        del self.root[id_]
+
+    def insert_chunk(self, id_, data=None):
+        """Insert a new chunk at the end of the IFF file"""
+        return self.root.insert_chunk(id_, data)

--- a/mutagen/_riff.py
+++ b/mutagen/_riff.py
@@ -12,291 +12,59 @@
 import struct
 from struct import pack
 
-from mutagen._util import (
-    MutagenError,
-    delete_bytes,
-    insert_bytes,
-    resize_bytes,
+from mutagen._iff import (
+    IffChunk,
+    IffContainerChunkMixin,
+    IffFile,
+    InvalidChunk,
 )
 
 
-class error(MutagenError):
-    pass
-
-
-class InvalidChunk(error):
-    pass
-
-
-def is_valid_chunk_id(id):
-    """ is_valid_chunk_id(FOURCC)
-
-    Arguments:
-        id (FOURCC)
-    Returns:
-        true if valid; otherwise false
-
-    Check if argument id is valid FOURCC type.
-    """
-
-    assert isinstance(id, str), \
-        'id is of type %s, must be str: %r' % (type(id), id)
-
-    if len(id) < 3 or len(id) > 4:
-        return False
-
-    for c in id:
-        if c < u'!' or c > u'~':
-            return False
-
-    return True
-
-
-#  Assert FOURCC formatted valid
-def assert_valid_chunk_id(id):
-    if not is_valid_chunk_id(id):
-        raise ValueError("Invalid RIFF-chunk-ID.")
-
-
-class RiffChunk(object):
+class RiffChunk(IffChunk):
     """Generic RIFF chunk"""
 
-    # Chunk headers are 8 bytes long (4 for ID and 4 for the size)
-    HEADER_SIZE = 8
-
     @classmethod
-    def parse(cls, fileobj, parent_chunk=None):
-        header = fileobj.read(cls.HEADER_SIZE)
-        if len(header) < cls.HEADER_SIZE:
-            raise InvalidChunk('Header size < %i' % cls.HEADER_SIZE)
-
-        id, data_size = struct.unpack('<4sI', header)
-        try:
-            id = id.decode('ascii').rstrip()
-        except UnicodeDecodeError as e:
-            raise InvalidChunk(e)
-
-        if not is_valid_chunk_id(id):
-            raise InvalidChunk('Invalid chunk ID %s' % id)
-
-        return cls.get_class(id)(fileobj, id, data_size, parent_chunk)
+    def parse_header(cls, header):
+        return struct.unpack('<4sI', header)
 
     @classmethod
     def get_class(cls, id):
         if id in (u'LIST', u'RIFF'):
-            return ListRiffChunk
+            return RiffListChunk
         else:
             return cls
 
-    def __init__(self, fileobj, id, data_size, parent_chunk):
-        self._fileobj = fileobj
-        self.id = id
-        self.data_size = data_size
-        self.parent_chunk = parent_chunk
-        self.data_offset = fileobj.tell()
-        self.offset = self.data_offset - self.HEADER_SIZE
-        self._calculate_size()
+    def write_new_header(self, id_, size):
+        self._fileobj.write(pack('<4sI', id_, size))
 
-    def read(self):
-        """Read the chunks data"""
-
-        self._fileobj.seek(self.data_offset)
-        return self._fileobj.read(self.data_size)
-
-    def write(self, data):
-        """Write the chunk data"""
-
-        if len(data) > self.data_size:
-            raise ValueError
-
-        self._fileobj.seek(self.data_offset)
-        self._fileobj.write(data)
-        # Write the padding bytes
-        padding = self.padding()
-        if padding:
-            self._fileobj.seek(self.data_offset + self.data_size)
-            self._fileobj.write(b'\x00' * padding)
-
-    def delete(self):
-        """Removes the chunk from the file"""
-
-        delete_bytes(self._fileobj, self.size, self.offset)
-        if self.parent_chunk is not None:
-            self.parent_chunk._remove_subchunk(self)
-        self._fileobj.flush()
-
-    def _update_size(self, size_diff, changed_subchunk=None):
-        """Update the size of the chunk"""
-
-        old_size = self.size
-        self.data_size += size_diff
-        self._fileobj.seek(self.offset + 4)
+    def write_size(self):
         self._fileobj.write(pack('<I', self.data_size))
-        self._calculate_size()
-        if self.parent_chunk is not None:
-            self.parent_chunk._update_size(self.size - old_size, self)
-        if changed_subchunk:
-            self._update_sibling_offsets(
-                changed_subchunk, old_size - self.size)
-
-    def _calculate_size(self):
-        # Consider the padding byte for the total size of this chunk
-        self.size = self.HEADER_SIZE + self.data_size + self.padding()
-        assert self.size % 2 == 0
-
-    def resize(self, new_data_size):
-        """Resize the file and update the chunk sizes"""
-
-        padding = new_data_size % 2
-        resize_bytes(self._fileobj, self.data_size + self.padding(),
-                     new_data_size + padding, self.data_offset)
-        size_diff = new_data_size - self.data_size
-        self._update_size(size_diff)
-        self._fileobj.flush()
-
-    def padding(self):
-        """Returns the number of padding bytes (0 or 1).
-        RIFF chunks are required to be a even number in total length. If
-        data_size is odd a padding byte will be added at the end.
-        """
-        return self.data_size % 2
 
 
-class ListRiffChunk(RiffChunk):
+class RiffListChunk(RiffChunk, IffContainerChunkMixin):
     """A RIFF chunk containing other chunks.
     This is either a 'LIST' or 'RIFF'
     """
 
-    MIN_DATA_SIZE = 4
+    def parse_next_subchunk(self):
+        return RiffChunk.parse(self._fileobj, self)
 
     def __init__(self, fileobj, id, data_size, parent_chunk):
         if id not in (u'RIFF', u'LIST'):
             raise InvalidChunk('Expected RIFF or LIST chunk, got %s' % id)
 
         RiffChunk.__init__(self, fileobj, id, data_size, parent_chunk)
-
-        # Lists always store an addtional identifier as 4 bytes
-        if data_size < self.MIN_DATA_SIZE:
-            raise InvalidChunk('List data size < %i' % self.MIN_DATA_SIZE)
-
-        # Read the list name (e.g. WAVE for RIFF chunks, or INFO for LIST)
-        try:
-            self.name = fileobj.read(4).decode('ascii')
-        except UnicodeDecodeError as e:
-            raise error(e)
-
-        # Load all RIFF subchunks
-        self.__subchunks = []
-
-    def subchunks(self):
-        """Returns a list of all subchunks.
-        The list is lazily loaded on first access.
-        """
-        if not self.__subchunks:
-            next_offset = self.data_offset + 4
-            while next_offset < self.offset + self.size:
-                self._fileobj.seek(next_offset)
-                try:
-                    chunk = RiffChunk.parse(self._fileobj, self)
-                except InvalidChunk:
-                    break
-                self.__subchunks.append(chunk)
-
-                # Calculate the location of the next chunk
-                next_offset = chunk.offset + chunk.size
-        return self.__subchunks
-
-    def insert_chunk(self, id_, data=None):
-        """Insert a new chunk at the end of the RIFF or LIST"""
-
-        assert isinstance(id_, str)
-
-        if not is_valid_chunk_id(id_):
-            raise KeyError("Invalid RIFF key.")
-
-        next_offset = self.offset + self.size
-        size = self.HEADER_SIZE
-        data_size = 0
-        if data:
-            data_size = len(data)
-            padding = data_size % 2
-            size += data_size + padding
-        insert_bytes(self._fileobj, size, next_offset)
-        self._fileobj.seek(next_offset)
-        self._fileobj.write(
-            pack('<4si', id_.ljust(4).encode('ascii'), data_size))
-        self._fileobj.seek(next_offset)
-        chunk = RiffChunk.parse(self._fileobj, self)
-        self._update_size(chunk.size)
-        if data:
-            chunk.write(data)
-        self.subchunks().append(chunk)
-        self._fileobj.flush()
-        return chunk
-
-    def _remove_subchunk(self, chunk):
-        assert chunk in self.__subchunks
-        self._update_size(-chunk.size, chunk)
-        self.__subchunks.remove(chunk)
-
-    def _update_sibling_offsets(self, changed_subchunk, size_diff):
-        """Update the offsets of subchunks after `changed_subchunk`.
-        """
-        index = self.__subchunks.index(changed_subchunk)
-        sibling_chunks = self.__subchunks[index + 1:len(self.__subchunks)]
-        for sibling in sibling_chunks:
-            sibling.offset -= size_diff
-            sibling.data_offset -= size_diff
+        self.init_container()
 
 
-class RiffFile(object):
-    """Representation of a RIFF file
-
-        Ref: http://www.johnloomis.org/cpe102/asgn/asgn1/riff.html
-      """
+class RiffFile(IffFile):
+    """Representation of a RIFF file"""
 
     def __init__(self, fileobj):
-        # Reset read pointer to beginning of RIFF file
-        fileobj.seek(0)
-
-        # RIFF Files always start with the RIFF chunk
-        self.root = RiffChunk.parse(fileobj)
+        super().__init__(RiffChunk, fileobj)
 
         if self.root.id != u'RIFF':
             raise InvalidChunk("Root chunk must be a RIFF chunk, got %s"
                                % self.root.id)
 
         self.file_type = self.root.name
-
-    def __contains__(self, id_):
-        """Check if the RIFF file contains a specific chunk"""
-
-        assert_valid_chunk_id(id_)
-        try:
-            self[id_]
-            return True
-        except KeyError:
-            return False
-
-    def __getitem__(self, id_):
-        """Get a chunk from the RIFF file"""
-
-        assert_valid_chunk_id(id_)
-        found_chunk = None
-        for chunk in self.root.subchunks():
-            if chunk.id == id_:
-                found_chunk = chunk
-                break
-        else:
-            raise KeyError("No %r chunk found" % id_)
-        return found_chunk
-
-    def delete_chunk(self, id_):
-        """Remove a chunk from the RIFF file"""
-
-        assert_valid_chunk_id(id_)
-        self[id_].delete()
-
-    def insert_chunk(self, id_, data=None):
-        """Insert a new chunk at the end of the RIFF file"""
-        return self.root.insert_chunk(id_, data)

--- a/mutagen/aiff.py
+++ b/mutagen/aiff.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2014  Evan Purkhiser
 #               2014  Ben Ockmore
-#               2019  Philipp Wolfer
+#               2019-2020  Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,13 +18,16 @@ from mutagen import StreamInfo, FileType
 
 from mutagen.id3 import ID3
 from mutagen.id3._util import ID3NoHeaderError, error as ID3Error
+from mutagen._iff import (
+    IffChunk,
+    IffContainerChunkMixin,
+    IffFile,
+    InvalidChunk,
+    error as IffError,
+)
 from mutagen._util import (
-    MutagenError,
     convert_error,
-    delete_bytes,
-    insert_bytes,
     loadfile,
-    resize_bytes,
     reraise,
     endswith,
 )
@@ -32,31 +35,12 @@ from mutagen._util import (
 __all__ = ["AIFF", "Open", "delete"]
 
 
-class error(MutagenError):
-    pass
-
-
-class InvalidChunk(error):
+class error(IffError):
     pass
 
 
 # based on stdlib's aifc
 _HUGE_VAL = 1.79769313486231e+308
-
-
-def is_valid_chunk_id(id):
-    assert isinstance(id, str)
-
-    return ((len(id) <= 4) and (min(id) >= u' ') and
-            (max(id) <= u'~'))
-
-
-def assert_valid_chunk_id(id):
-
-    assert isinstance(id, str)
-
-    if not is_valid_chunk_id(id):
-        raise ValueError("AIFF key must be four ASCII characters.")
 
 
 def read_float(data):
@@ -79,251 +63,62 @@ def read_float(data):
     return sign * f
 
 
-class IFFChunk(object):
+class AIFFChunk(IffChunk):
     """Representation of a single IFF chunk"""
 
-    # Chunk headers are 8 bytes long (4 for ID and 4 for the size)
-    HEADER_SIZE = 8
-
     @classmethod
-    def parse(cls, fileobj, parent_chunk=None):
-        header = fileobj.read(cls.HEADER_SIZE)
-        if len(header) < cls.HEADER_SIZE:
-            raise InvalidChunk('Header size < %i' % cls.HEADER_SIZE)
-
-        id, data_size = struct.unpack('>4sI', header)
-        try:
-            id = id.decode('ascii').rstrip()
-        except UnicodeDecodeError as e:
-            raise InvalidChunk(e)
-
-        if not is_valid_chunk_id(id):
-            raise InvalidChunk('Invalid chunk ID %s' % id)
-
-        return cls.get_class(id)(fileobj, id, data_size, parent_chunk)
+    def parse_header(cls, header):
+        return struct.unpack('>4sI', header)
 
     @classmethod
     def get_class(cls, id):
         if id == 'FORM':
-            return FormIFFChunk
+            return AIFFFormChunk
         else:
             return cls
 
-    def __init__(self, fileobj, id, data_size, parent_chunk):
-        self._fileobj = fileobj
-        self.id = id
-        self.data_size = data_size
-        self.parent_chunk = parent_chunk
-        self.data_offset = fileobj.tell()
-        self.offset = self.data_offset - self.HEADER_SIZE
-        self._calculate_size()
+    def write_new_header(self, id_, size):
+        self._fileobj.write(pack('>4sI', id_, size))
 
-    def read(self):
-        """Read the chunks data"""
-
-        self._fileobj.seek(self.data_offset)
-        return self._fileobj.read(self.data_size)
-
-    def write(self, data):
-        """Write the chunk data"""
-
-        if len(data) > self.data_size:
-            raise ValueError
-
-        self._fileobj.seek(self.data_offset)
-        self._fileobj.write(data)
-        # Write the padding bytes
-        padding = self.padding()
-        if padding:
-            self._fileobj.seek(self.data_offset + self.data_size)
-            self._fileobj.write(b'\x00' * padding)
-
-    def delete(self):
-        """Removes the chunk from the file"""
-
-        delete_bytes(self._fileobj, self.size, self.offset)
-        if self.parent_chunk is not None:
-            self.parent_chunk._remove_subchunk(self)
-        self._fileobj.flush()
-
-    def _update_size(self, size_diff, changed_subchunk=None):
-        """Update the size of the chunk"""
-
-        old_size = self.size
-        self.data_size += size_diff
-        self._fileobj.seek(self.offset + 4)
+    def write_size(self):
         self._fileobj.write(pack('>I', self.data_size))
-        self._calculate_size()
-        if self.parent_chunk is not None:
-            self.parent_chunk._update_size(self.size - old_size, self)
-        if changed_subchunk:
-            self._update_sibling_offsets(
-                changed_subchunk, old_size - self.size)
-
-    def _calculate_size(self):
-        self.size = self.HEADER_SIZE + self.data_size + self.padding()
-        assert self.size % 2 == 0
-
-    def resize(self, new_data_size):
-        """Resize the file and update the chunk sizes"""
-
-        padding = new_data_size % 2
-        resize_bytes(self._fileobj, self.data_size + self.padding(),
-                     new_data_size + padding, self.data_offset)
-        size_diff = new_data_size - self.data_size
-        self._update_size(size_diff)
-        self._fileobj.flush()
-
-    def padding(self):
-        """Returns the number of padding bytes (0 or 1).
-        IFF chunks are required to be a even number in total length. If
-        data_size is odd a padding byte will be added at the end.
-        """
-        return self.data_size % 2
 
 
-class FormIFFChunk(IFFChunk):
-    """A IFF chunk containing other chunks.
-    This is either a 'LIST' or 'RIFF'
-    """
+class AIFFFormChunk(AIFFChunk, IffContainerChunkMixin):
+    """The  AIFF root chunk."""
 
-    MIN_DATA_SIZE = 4
+    def parse_next_subchunk(self):
+        return AIFFChunk.parse(self._fileobj, self)
 
     def __init__(self, fileobj, id, data_size, parent_chunk):
         if id != u'FORM':
             raise InvalidChunk('Expected FORM chunk, got %s' % id)
 
-        IFFChunk.__init__(self, fileobj, id, data_size, parent_chunk)
-
-        # Lists always store an addtional identifier as 4 bytes
-        if data_size < self.MIN_DATA_SIZE:
-            raise InvalidChunk('FORM data size < %i' % self.MIN_DATA_SIZE)
-
-        # Read the FORM id (usually AIFF)
-        try:
-            self.name = fileobj.read(4).decode('ascii')
-        except UnicodeDecodeError as e:
-            raise error(e)
-
-        # Load all IFF subchunks
-        self.__subchunks = []
-
-    def subchunks(self):
-        """Returns a list of all subchunks.
-        The list is lazily loaded on first access.
-        """
-        if not self.__subchunks:
-            next_offset = self.data_offset + 4
-            while next_offset < self.offset + self.size:
-                self._fileobj.seek(next_offset)
-                try:
-                    chunk = IFFChunk.parse(self._fileobj, self)
-                except InvalidChunk:
-                    break
-                self.__subchunks.append(chunk)
-
-                # Calculate the location of the next chunk
-                next_offset = chunk.offset + chunk.size
-        return self.__subchunks
-
-    def insert_chunk(self, id_, data=None):
-        """Insert a new chunk at the end of the FORM chunk"""
-
-        assert isinstance(id_, str)
-
-        if not is_valid_chunk_id(id_):
-            raise KeyError("Invalid IFF key.")
-
-        next_offset = self.offset + self.size
-        size = self.HEADER_SIZE
-        data_size = 0
-        if data:
-            data_size = len(data)
-            padding = data_size % 2
-            size += data_size + padding
-        insert_bytes(self._fileobj, size, next_offset)
-        self._fileobj.seek(next_offset)
-        self._fileobj.write(
-            pack('>4si', id_.ljust(4).encode('ascii'), data_size))
-        self._fileobj.seek(next_offset)
-        chunk = IFFChunk.parse(self._fileobj, self)
-        self._update_size(chunk.size)
-        if data:
-            chunk.write(data)
-        self.subchunks().append(chunk)
-        self._fileobj.flush()
-        return chunk
-
-    def _remove_subchunk(self, chunk):
-        assert chunk in self.__subchunks
-        self._update_size(-chunk.size, chunk)
-        self.__subchunks.remove(chunk)
-
-    def _update_sibling_offsets(self, changed_subchunk, size_diff):
-        """Update the offsets of subchunks after `changed_subchunk`.
-        """
-        index = self.__subchunks.index(changed_subchunk)
-        sibling_chunks = self.__subchunks[index + 1:len(self.__subchunks)]
-        for sibling in sibling_chunks:
-            sibling.offset -= size_diff
-            sibling.data_offset -= size_diff
+        AIFFChunk.__init__(self, fileobj, id, data_size, parent_chunk)
+        self.init_container()
 
 
-class IFFFile(object):
-    """Representation of a IFF file"""
+class AIFFFile(IffFile):
+    """Representation of a AIFF file"""
 
     def __init__(self, fileobj):
         # AIFF Files always start with the FORM chunk which contains a 4 byte
         # ID before the start of other chunks
-        fileobj.seek(0)
-        self.root = IFFChunk.parse(fileobj)
+        super().__init__(AIFFChunk, fileobj)
 
         if self.root.id != u'FORM':
-            raise InvalidChunk("Root chunk must be a RIFF chunk, got %s"
+            raise InvalidChunk("Root chunk must be a FORM chunk, got %s"
                                % self.root.id)
 
     def __contains__(self, id_):
-        """Check if the IFF file contains a specific chunk"""
-
-        assert_valid_chunk_id(id_)
-        try:
-            self[id_]
+        if id_ == 'FORM':  # For backwards compatibility
             return True
-        except KeyError:
-            return False
+        return super().__contains__(id_)
 
     def __getitem__(self, id_):
-        """Get a chunk from the IFF file"""
-
-        assert_valid_chunk_id(id_)
         if id_ == 'FORM':  # For backwards compatibility
             return self.root
-        found_chunk = None
-        for chunk in self.root.subchunks():
-            if chunk.id == id_:
-                found_chunk = chunk
-                break
-        else:
-            raise KeyError("No %r chunk found" % id_)
-        return found_chunk
-
-    def __delitem__(self, id_):
-        """Remove a chunk from the IFF file"""
-
-        assert_valid_chunk_id(id_)
-        self.delete_chunk(id_)
-
-    def delete_chunk(self, id_):
-        """Remove a chunk from the RIFF file"""
-
-        assert_valid_chunk_id(id_)
-        self[id_].delete()
-
-    def insert_chunk(self, id_, data=None):
-        """Insert a new chunk at the end of the IFF file"""
-
-        assert_valid_chunk_id(id_)
-        return self.root.insert_chunk(id_, data)
+        return super().__getitem__(id_)
 
 
 class AIFFInfo(StreamInfo):
@@ -350,7 +145,7 @@ class AIFFInfo(StreamInfo):
     def __init__(self, fileobj):
         """Raises error"""
 
-        iff = IFFFile(fileobj)
+        iff = AIFFFile(fileobj)
         try:
             common_chunk = iff[u'COMM']
         except KeyError as e:
@@ -387,7 +182,7 @@ class _IFFID3(ID3):
 
     def _pre_load_header(self, fileobj):
         try:
-            fileobj.seek(IFFFile(fileobj)[u'ID3'].data_offset)
+            fileobj.seek(AIFFFile(fileobj)[u'ID3'].data_offset)
         except (InvalidChunk, KeyError):
             raise ID3NoHeaderError("No ID3 chunk")
 
@@ -398,7 +193,7 @@ class _IFFID3(ID3):
 
         fileobj = filething.fileobj
 
-        iff_file = IFFFile(fileobj)
+        iff_file = AIFFFile(fileobj)
 
         if u'ID3' not in iff_file:
             iff_file.insert_chunk(u'ID3')
@@ -429,7 +224,7 @@ def delete(filething):
     """Completely removes the ID3 chunk from the AIFF file"""
 
     try:
-        del IFFFile(filething.fileobj)[u'ID3']
+        del AIFFFile(filething.fileobj)[u'ID3']
     except KeyError:
         pass
 

--- a/mutagen/wave.py
+++ b/mutagen/wave.py
@@ -16,9 +16,9 @@ from mutagen import StreamInfo, FileType
 
 from mutagen.id3 import ID3
 from mutagen._riff import RiffFile, InvalidChunk
+from mutagen._iff import error as IffError
 from mutagen.id3._util import ID3NoHeaderError, error as ID3Error
 from mutagen._util import (
-    MutagenError,
     convert_error,
     endswith,
     loadfile,
@@ -28,7 +28,7 @@ from mutagen._util import (
 __all__ = ["WAVE", "Open", "delete"]
 
 
-class error(MutagenError):
+class error(IffError):
     """WAVE stream parsing errors."""
 
 

--- a/tests/test_aiff.py
+++ b/tests/test_aiff.py
@@ -175,7 +175,7 @@ class TAIFF(TestCase):
         self.assertEqual(AIFF(self.filename_1).tags._padding, 100)
 
         tags = AIFF(self.filename_1)
-        self.assertRaises(AIFFError, tags.save, padding=lambda x: -1)
+        self.assertRaises(IffError, tags.save, padding=lambda x: -1)
 
     def tearDown(self):
         os.unlink(self.filename_1)

--- a/tests/test_aiff.py
+++ b/tests/test_aiff.py
@@ -3,8 +3,9 @@
 import os
 from io import BytesIO
 
-from mutagen.aiff import AIFF, AIFFInfo, delete, IFFFile, IFFChunk
+from mutagen.aiff import AIFF, AIFFInfo, delete, AIFFFile, AIFFChunk
 from mutagen.aiff import error as AIFFError, read_float
+from mutagen._iff import error as IffError
 
 from tests import TestCase, DATA_DIR, get_temp_copy
 
@@ -84,7 +85,7 @@ class TAIFF(TestCase):
 
     def test_notaiff(self):
         self.failUnlessRaises(
-            AIFFError, AIFF, os.path.join(DATA_DIR, 'empty.ofr'))
+            IffError, AIFF, os.path.join(DATA_DIR, 'empty.ofr'))
 
     def test_pprint(self):
         self.failUnless(self.aiff_1.pprint())
@@ -153,7 +154,7 @@ class TAIFF(TestCase):
 
     def test_corrupt_tag(self):
         with open(self.filename_1, "r+b") as h:
-            chunk = IFFFile(h)[u'ID3']
+            chunk = AIFFFile(h)[u'ID3']
             h.seek(chunk.data_offset)
             h.seek(4, 1)
             h.write(b"\xff\xff")
@@ -185,26 +186,26 @@ class TAIFFInfo(TestCase):
 
     def test_empty(self):
         fileobj = BytesIO(b"")
-        self.failUnlessRaises(AIFFError, AIFFInfo, fileobj)
+        self.failUnlessRaises(IffError, AIFFInfo, fileobj)
 
 
-class TIFFFile(TestCase):
+class TAIFFFile(TestCase):
     has_tags = os.path.join(DATA_DIR, 'with-id3.aif')
     no_tags = os.path.join(DATA_DIR, '8k-1ch-1s-silence.aif')
 
     def setUp(self):
         self.file_1 = open(self.has_tags, 'rb')
-        self.iff_1 = IFFFile(self.file_1)
+        self.iff_1 = AIFFFile(self.file_1)
         self.file_2 = open(self.no_tags, 'rb')
-        self.iff_2 = IFFFile(self.file_2)
+        self.iff_2 = AIFFFile(self.file_2)
 
         self.tmp_1_name = get_temp_copy(self.has_tags)
         self.file_1_tmp = open(self.tmp_1_name, 'rb+')
-        self.iff_1_tmp = IFFFile(self.file_1_tmp)
+        self.iff_1_tmp = AIFFFile(self.file_1_tmp)
 
         self.tmp_2_name = get_temp_copy(self.no_tags)
         self.file_2_tmp = open(self.tmp_2_name, 'rb+')
-        self.iff_2_tmp = IFFFile(self.file_2_tmp)
+        self.iff_2_tmp = AIFFFile(self.file_2_tmp)
 
     def tearDown(self):
         self.file_1.close()
@@ -225,10 +226,10 @@ class TIFFFile(TestCase):
         self.failUnless(u'SSND' in self.iff_2)
 
     def test_is_chunks(self):
-        self.failUnless(isinstance(self.iff_1[u'FORM'], IFFChunk))
-        self.failUnless(isinstance(self.iff_1[u'COMM'], IFFChunk))
-        self.failUnless(isinstance(self.iff_1[u'SSND'], IFFChunk))
-        self.failUnless(isinstance(self.iff_1[u'ID3'], IFFChunk))
+        self.failUnless(isinstance(self.iff_1[u'FORM'], AIFFChunk))
+        self.failUnless(isinstance(self.iff_1[u'COMM'], AIFFChunk))
+        self.failUnless(isinstance(self.iff_1[u'SSND'], AIFFChunk))
+        self.failUnless(isinstance(self.iff_1[u'ID3'], AIFFChunk))
 
     def test_chunk_size(self):
         self.failUnlessEqual(self.iff_1[u'FORM'].size, 17096)
@@ -241,9 +242,9 @@ class TIFFFile(TestCase):
     def test_FORM_chunk_resize(self):
         self.iff_1_tmp[u'FORM'].resize(17000)
         self.failUnlessEqual(
-            IFFFile(self.file_1_tmp)[u'FORM'].data_size, 17000)
+            AIFFFile(self.file_1_tmp)[u'FORM'].data_size, 17000)
         self.iff_2_tmp[u'FORM'].resize(4)
-        self.failUnlessEqual(IFFFile(self.file_2_tmp)[u'FORM'].data_size, 4)
+        self.failUnlessEqual(AIFFFile(self.file_2_tmp)[u'FORM'].data_size, 4)
 
     def test_child_chunk_resize(self):
         self.iff_1_tmp[u'ID3'].resize(128)
@@ -252,26 +253,26 @@ class TIFFFile(TestCase):
         id3.write(b"\xff" * 128)
         self.assertEqual(id3.read(), b"\xff" * 128)
 
-        self.failUnlessEqual(IFFFile(self.file_1_tmp)[u'ID3'].data_size, 128)
+        self.failUnlessEqual(AIFFFile(self.file_1_tmp)[u'ID3'].data_size, 128)
         self.failUnlessEqual(
-            IFFFile(self.file_1_tmp)[u'FORM'].data_size, 16182)
+            AIFFFile(self.file_1_tmp)[u'FORM'].data_size, 16182)
 
     def test_chunk_delete(self):
         del self.iff_1_tmp[u'ID3']
         self.failIf(u'ID3' in self.iff_1_tmp)
-        self.failIf(u'ID3' in IFFFile(self.file_1_tmp))
-        self.failUnlessEqual(IFFFile(self.file_1_tmp)[u'FORM'].size, 16054)
+        self.failIf(u'ID3' in AIFFFile(self.file_1_tmp))
+        self.failUnlessEqual(AIFFFile(self.file_1_tmp)[u'FORM'].size, 16054)
         del self.iff_2_tmp[u'SSND']
         self.failIf(u'SSND' in self.iff_2_tmp)
-        self.failIf(u'SSND' in IFFFile(self.file_2_tmp))
-        self.failUnlessEqual(IFFFile(self.file_2_tmp)[u'FORM'].size, 38)
+        self.failIf(u'SSND' in AIFFFile(self.file_2_tmp))
+        self.failUnlessEqual(AIFFFile(self.file_2_tmp)[u'FORM'].size, 38)
 
     def test_insert_chunk(self):
         self.iff_2_tmp.insert_chunk(u'ID3')
 
-        new_iff = IFFFile(self.file_2_tmp)
+        new_iff = AIFFFile(self.file_2_tmp)
         self.failUnless(u'ID3' in new_iff)
-        self.failUnless(isinstance(new_iff[u'ID3'], IFFChunk))
+        self.failUnless(isinstance(new_iff[u'ID3'], AIFFChunk))
         self.failUnlessEqual(new_iff[u'FORM'].size, 16062)
         self.failUnlessEqual(new_iff[u'FORM'].data_size, 16054)
         self.failUnlessEqual(new_iff[u'ID3'].size, 8)
@@ -325,7 +326,7 @@ class TIFFFile(TestCase):
         self.failUnlessEqual(iff_file[u'TST2'].data_size, 2)
         self.failUnlessEqual(iff_file[u'TST2'].data_offset, 16062)
         # Reloading the file should give the same results
-        new_iff_file = IFFFile(self.file_2_tmp)
+        new_iff_file = AIFFFile(self.file_2_tmp)
         self.failUnlessEqual(new_iff_file[u'FORM'].size,
                              iff_file[u'FORM'].size)
         self.failUnlessEqual(new_iff_file[u'TST2'].size,


### PR DESCRIPTION
Update the AIFF and RIFF implementations to use common IFF base classes. Both the AIFF and RIFF implementations share a lot of code. The differences between both implementations is that one uses big endian and the other little endian, also they obviously use different types of chunks.

The background for this is that I am also working on a DSDIFF (aka DFF) implementation. DSDIFF is also IFF based and thus again shares most of the code of the AIFF / RIFF implementations. The main difference to AIFF is that DSDIFF uses 8 bytes for the length instead of 4.

So I'm submitting this refactoring first and later the DSDIFF changes on top of this.