### PR TITLE
Fixes issue #471: Google App Engine Appstats module TypeError

### DIFF
--- a/mutagen/mp3/__init__.py
+++ b/mutagen/mp3/__init__.py
@@ -37,7 +37,11 @@ class InvalidMPEGHeader(error):
 
 @enum
 class BitrateMode(object):
-
+    # no-op to satisfy function for GAE's appstat module.
+    # If you use appstats in your project this will be necessary to
+    # satisfy the TypeError where __dict__ descriptor is needed. 
+    def __dict__(self, object):
+        return ''
     UNKNOWN = 0
     """Probably a CBR file, but not sure"""
 

--- a/tests/test_mp3.py
+++ b/tests/test_mp3.py
@@ -72,6 +72,9 @@ class TMP3(TestCase):
         self.failUnlessEqual(self.mp3_3.info.mode, JOINTSTEREO)
         self.failUnlessEqual(self.mp3_4.info.mode, JOINTSTEREO)
 
+    def test_dict_descriptor(self):
+        self.assertEqual(self.mp3.__dict__, '')
+
     def test_replaygain(self):
         self.assertEqual(self.mp3_3.info.track_gain, 51.0)
         self.assertEqual(self.mp3_4.info.track_gain, 51.0)


### PR DESCRIPTION
This PR fixes a niche error for the Google App Engine's appstats module as described by #471. 
Fixes the issue where __dict__ descriptor is not provided and throws a TypeError. 

This is done as a noop function as it just needs to satisfy the appstats module.

This is clearly meant for the python 2 supported version as it's niche. 

