### PR TITLE
Don't use mmap for rewriting files

### DIFF
--- a/docs/user/examples/fileobj-iface.py
+++ b/docs/user/examples/fileobj-iface.py
@@ -101,7 +101,7 @@ class IOInterface(object):
         """Returns the file descriptor (int) or raises IOError
         if there is none.
 
-        Will be used for mmap if available.
+        Will be used for low level operations if available.
         """
 
         raise NotImplementedError


### PR DESCRIPTION
It has some problems with Windows file shares where it takes 20x the time
of the fallback implementation and has a similar problem with ZFS on Linux,
see #478.

I've done some basic benchmarks with adding extra padding to 30 flac files each around
20-40MB and there is basically no difference.

So just remove mmap.

Fixes #478