### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, pypy3]
+        python-version: [3.6, 3.7, 3.8, pypy3]
         exclude:
           # hangs
           - os: macos-latest
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.5, 3.8]
+        python-version: [3.6, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ It can read Xing headers to accurately calculate the bitrate and length of
 MP3s. ID3 and APEv2 tags can be edited regardless of audio format. It can also
 manipulate Ogg streams on an individual packet/page level.
 
-Mutagen works with Python 3.5+ (CPython and PyPy) on Linux, Windows and
+Mutagen works with Python 3.6+ (CPython and PyPy) on Linux, Windows and
 macOS, and has no dependencies outside the Python standard library. Mutagen
 is licensed under the GPL version 2 or later.
 

--- a/setup.py
+++ b/setup.py
@@ -280,7 +280,6 @@ if __name__ == "__main__":
           classifiers=[
             'Operating System :: OS Independent',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
@@ -303,7 +302,7 @@ if __name__ == "__main__":
             ('share/man/man1', glob.glob("man/*.1")),
           ],
           python_requires=(
-            '>=3.5, <4'),
+            '>=3.6, <4'),
           entry_points={
             'console_scripts': [
               'mid3cp=mutagen._tools.mid3cp:entry_point',


### PR DESCRIPTION
We now require 3.6+.

The main motivation for this change is improved
type annotation support, see #486