### PR TITLE
flac: handle files where the first metadata block is not STREAMINFO

### DIFF
--- a/mutagen/flac.py
+++ b/mutagen/flac.py
@@ -797,7 +797,7 @@ class FLAC(mutagen.FileType):
             pass
 
         try:
-            self.metadata_blocks[0].length
+            self.info.length
         except (AttributeError, IndexError):
             raise FLACNoHeaderError("Stream info block not found")
 
@@ -811,7 +811,11 @@ class FLAC(mutagen.FileType):
 
     @property
     def info(self):
-        return self.metadata_blocks[0]
+        streaminfo_blocks = [
+            block for block in self.metadata_blocks
+            if block.code == StreamInfo.code
+        ]
+        return streaminfo_blocks[0]
 
     def add_picture(self, picture):
         """Add a new picture to the file.


### PR DESCRIPTION
I recently bought some FLAC files from Warp's Bleep store and was surprised to discover that mutagen crashes as follows when processing them (snaffleid3 is a script I wrote):

```
Traceback (most recent call last):                                      
  File "/usr/bin/snaffleid3", line 54, in <module>                           
    f = FLAC(flac.rstrip("\n"))                                             
  File "/usr/lib/python2.7/dist-packages/mutagen/_file.py", line 49, in __init__
    self.load(*args, **kwargs)                                                                                      
  File "/usr/lib/python2.7/dist-packages/mutagen/_util.py", line 169, in wrapper                    
    return func(*args, **kwargs)                                        
  File "/usr/lib/python2.7/dist-packages/mutagen/_util.py", line 140, in wrapper
    return func(self, h, *args, **kwargs)                                                                              
  File "/usr/lib/python2.7/dist-packages/mutagen/flac.py", line 796, in load                                           
    raise FLACNoHeaderError("Stream info block not found")             
mutagen.flac.FLACNoHeaderError: Stream info block not found                      
```

This seems to be because mutagen expects the first metadata block to be STREAMINFO, but in the case of my shiny new Bleep files, it's PICTURE:

```
$ metaflac --list SIGN-001-Autechre-M4\ Lema.flac | grep -A1 ^META
METADATA block #0
  type: 6 (PICTURE)
--
METADATA block #1
  type: 0 (STREAMINFO)
--
METADATA block #2
  type: 4 (VORBIS_COMMENT)
--
METADATA block #3
  type: 1 (PADDING)
$ _
```

This branch changes mutagen to find STREAMINFO by code instead of by index.

Before and after, this time with a script that I didn't write:
```
$ mutagen-inspect SIGN-001-Autechre-M4\ Lema.flac 
-- SIGN-001-Autechre-M4 Lema.flac
Stream info block not found
$ # [ apply patch... ]
$ mutagen-inspect SIGN-001-Autechre-M4\ Lema.flac 
-- SIGN-001-Autechre-M4 Lema.flac
- FLAC, 529.70 seconds, 44100 Hz (audio/flac)
TITLE=M4 Lema
ARTIST=Autechre
ALBUM=SIGN
COMPOSER=Sean Booth / Rob Brown
TRACKNUMBER=1
ALBUM ARTIST=Autechre
ALBUMARTIST=Autechre
ISRC=GBBPW2000091
$ _