### PR TITLE
Map easyid3 grouping to TIT1

### DIFF
--- a/mutagen/easyid3.py
+++ b/mutagen/easyid3.py
@@ -479,6 +479,7 @@ for frameid, key in {
     "TLEN": "length",
     "TMED": "media",
     "TMOO": "mood",
+    "TIT1": "grouping",
     "TIT2": "title",
     "TIT3": "version",
     "TPE1": "artist",


### PR DESCRIPTION
According to the specification,

> The 'Content group description' frame [TIT1] is used if the sound belongs to a larger category of sounds/music. For example, classical music is often sorted in different musical sections (e.g. "Piano Concerto", "Weather - Hurricane"). 

which seems like the same thing as ‘grouping’.