### PR TITLE
Fix cuesheet and seektable saving in FLAC

### DIFF
--- a/mutagen/flac.py
+++ b/mutagen/flac.py
@@ -519,7 +519,7 @@ class CueSheet(MetadataBlock):
                 track_flags |= 0x40
             track_packed = struct.pack(
                 self.__CUESHEET_TRACK_FORMAT, track.start_offset,
-                track.track_number, track.isrc, track_flags,
+                track.track_number, track.isrc or b"\0", track_flags,
                 len(track.indexes))
             f.write(track_packed)
             for index in track.indexes:
@@ -846,6 +846,15 @@ class FLAC(mutagen.FileType):
 
         If no filename is given, the one most recently loaded is used.
         """
+        # add new cuesheet and seektable
+        if self.cuesheet and self.cuesheet not in self.metadata_blocks:
+            if not isinstance(self.cuesheet, CueSheet):
+                raise ValueError("Invalid cuesheet object type!")
+            self.metadata_blocks.append(self.cuesheet)
+        if self.seektable and self.seektable not in self.metadata_blocks:
+            if not isinstance(self.seektable, SeekTable):
+                raise ValueError("Invalid seektable object type!")
+            self.metadata_blocks.append(self.seektable)
 
         self._save(filething, self.metadata_blocks, deleteid3, padding)
 


### PR DESCRIPTION
I meet the problem when I'm trying to create a Cuesheet block for FLAC and save. When I directly specify `tags.cuesheet = XXX`, the cuesheet tag won't be saved unless I manually add the cuesheet object also to the `metadata_blocks`. This PR changes this behavior so that the cuesheet block will always be saved.

This PR also fix the problem when the ISRC value for a cuesheet track is empty (`None`)