### PR TITLE
Add usage documentation for mutagen-inspect

### DIFF
--- a/mutagen/_tools/mutagen_inspect.py
+++ b/mutagen/_tools/mutagen_inspect.py
@@ -18,7 +18,7 @@ _sig = SignalHandler()
 def main(argv):
     from mutagen import File
 
-    parser = OptionParser()
+    parser = OptionParser(usage="usage: %prog [options] FILE [FILE...]")
     parser.add_option("--no-flac", help="Compatibility; does nothing.")
     parser.add_option("--no-mp3", help="Compatibility; does nothing.")
     parser.add_option("--no-apev2", help="Compatibility; does nothing.")


### PR DESCRIPTION
Small PR to update the `mutagen-inspect` usage help text from:

```bash
$ mutagen-inspect --help
Usage: mutagen-inspect [options]

Options:
  -h, --help           show this help message and exit
  --no-flac=NO_FLAC    Compatibility; does nothing.
  --no-mp3=NO_MP3      Compatibility; does nothing.
  --no-apev2=NO_APEV2  Compatibility; does nothing.
```

to:

```bash
$ mutagen-inspect --help
Usage: mutagen-inspect [options] FILE [FILE...]

Options:
  -h, --help           show this help message and exit
  --no-flac=NO_FLAC    Compatibility; does nothing.
  --no-mp3=NO_MP3      Compatibility; does nothing.
  --no-apev2=NO_APEV2  Compatibility; does nothing.
```
