### PR TITLE
Note that a FileType's `tags` attribute may be None

### DIFF
--- a/docs/user/classes.rst
+++ b/docs/user/classes.rst
@@ -40,8 +40,8 @@ It provides a dict-like interface which acts as a proxy to the containing
 Tags
 ----
 
-Each FileType has an attribute `tags` which holds a :class:`Tags` instance. If the
-file's tags failed to be read, `tags` is set to `None`.
+Each FileType has an attribute ``tags`` which holds a :class:`Tags` instance. If the
+file's tags failed to be read, ``tags`` is set to ``None``.
 
 The Tags interface depends mostly on each format. It exposes a dict-like interface
 where the type of keys and values depends on the implementation of each

--- a/docs/user/classes.rst
+++ b/docs/user/classes.rst
@@ -40,8 +40,10 @@ It provides a dict-like interface which acts as a proxy to the containing
 Tags
 ----
 
-Each FileType has an attribute tags which holds a :class:`Tags` instance. The
-Tags interface depends mostly on each format. It exposes a dict-like interface
+Each FileType has an attribute `tags` which holds a :class:`Tags` instance. If the
+file's tags failed to be read, `tags` is set to `None`.
+
+The Tags interface depends mostly on each format. It exposes a dict-like interface
 where the type of keys and values depends on the implementation of each
 format.
 


### PR DESCRIPTION
The `tags` attribute of a `FileType` object can be `None` if the tags failed to be read. For example, in `ID3FileType`:

https://github.com/quodlibet/mutagen/blob/30f373fa6d56e1afa17d48a0c6f3e111267fbd32/mutagen/id3/_file.py#L407-L410

This PR mentions this in the documentation.