### PR TITLE
Fix a bug about wrong order of function arguments

### DIFF
--- a/mutagen/flac.py
+++ b/mutagen/flac.py
@@ -280,7 +280,7 @@ class SeekPoint(tuple):
     """
 
     def __new__(cls, first_sample, byte_offset, num_samples):
-        return super(cls, SeekPoint).__new__(
+        return super(SeekPoint, cls).__new__(
             cls, (first_sample, byte_offset, num_samples))
 
     def __getnewargs__(self):
@@ -373,7 +373,7 @@ class CueSheetTrackIndex(tuple):
     """
 
     def __new__(cls, index_number, index_offset):
-        return super(cls, CueSheetTrackIndex).__new__(
+        return super(CueSheetTrackIndex, cls).__new__(
             cls, (index_number, index_offset))
 
     index_number = property(lambda self: self[0])


### PR DESCRIPTION
Hi,

This pull request is a fix to a potential bug about wrong order of function arguments at `mutagen/flac.py`. Please check the changes.

When calling `super`, the first argument should be the class name (see [this](https://stackoverflow.com/questions/8972866/correct-way-to-use-super-argument-passing)).

Best,
Jingxuan