### PR TITLE
docs: Fix a few typos

### DIFF
--- a/mutagen/flac.py
+++ b/mutagen/flac.py
@@ -712,7 +712,7 @@ class FLAC(mutagen.FileType):
         if block_type._distrust_size:
             # Some jackass is writing broken Metadata block length
             # for Vorbis comment blocks, and the FLAC reference
-            # implementaton can parse them (mostly by accident),
+            # implementation can parse them (mostly by accident),
             # so we have to too.  Instead of parsing the size
             # given, parse an actual Vorbis comment, leaving
             # fileobj in the right position.

--- a/mutagen/ogg.py
+++ b/mutagen/ogg.py
@@ -213,7 +213,7 @@ class OggPage(object):
         to logical stream 'serial'. Other pages will be ignored.
 
         fileobj must point to the start of a valid Ogg page; any
-        occuring after it and part of the specified logical stream
+        occurring after it and part of the specified logical stream
         will be numbered. No adjustment will be made to the data in
         the pages nor the granule position; only the page number, and
         so also the CRC.


### PR DESCRIPTION
There are small typos in:
- mutagen/flac.py
- mutagen/ogg.py

Fixes:
- Should read `occurring` rather than `occuring`.
- Should read `implementation` rather than `implementaton`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md