### PR TITLE
Wav bitrate fix

### DIFF
--- a/mutagen/wave.py
+++ b/mutagen/wave.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2017  Borewit
 # Copyright (C) 2019-2020  Philipp Wolfer
 #

--- a/mutagen/wave.py
+++ b/mutagen/wave.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (C) 2017  Borewit
 # Copyright (C) 2019-2020  Philipp Wolfer
 #
@@ -88,7 +89,7 @@ class WaveStreamInfo(StreamInfo):
         info = struct.unpack('<hhLLhh', data[:self.SIZE])
         self.audio_format, self.channels, self.sample_rate, byte_rate, \
             block_align, self.bits_per_sample = info
-        self.bitrate = self.channels * block_align * self.sample_rate
+        self.bitrate = self.channels * self.bits_per_sample * self.sample_rate
 
         # Calculate duration
         self._number_of_samples = 0

--- a/tests/test_wave.py
+++ b/tests/test_wave.py
@@ -55,9 +55,9 @@ class TWave(TestCase):
 
     def test_bitrate(self):
         self.failUnlessEqual(self.wav_pcm_2s_16000_08_ID3v23.
-                             info.bitrate, 64000)
+                             info.bitrate, 256000)
         self.failUnlessEqual(self.wav_pcm_2s_44100_16_ID3v23.
-                             info.bitrate, 352800)
+                             info.bitrate, 1411200)
 
     def test_length(self):
         self.failUnlessAlmostEqual(self.wav_pcm_2s_16000_08_ID3v23.info.length,


### PR DESCRIPTION
Calculated bitrate for WAVE files did not match correct value (as shown in foobar2000 or calculated manually)

Should be: num channels * bits per sample * sample rate

Tests for WAVE were checking incorrect values for bitrate. Redbook audio (stereo, 16bit, 44100Hz) for example should have a bitrate of 1411200 bits per second.