### PR TITLE
CI: test with Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, pypy-3.7]
+        python-version: [3.7, 3.8, 3.9, '3.10', pypy-3.7]
         exclude:
           # hangs
           - os: macos-latest
@@ -31,7 +31,7 @@ jobs:
             python-version: 3.7
             build-docs: true
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.10
             build-docs: true
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,11 @@ python-afl = {version = "^0.7.3", optional = true}
 fuzzing-dev = ["python-afl"]
 
 [tool.poetry.dev-dependencies]
-pytest = "^6.2.2"
-hypothesis = "^6.2.0"
-flake8 = "^3.8.4"
-mypy = {version = "^0.800", markers = "platform_python_implementation != 'PyPy'"}
-coverage = "^5.4"
+pytest = "^7.1.2"
+hypothesis = "^6.50.1"
+flake8 = "^4.0.1"
+mypy = {version = "^0.961", markers = "platform_python_implementation != 'PyPy'"}
+coverage = "^6.4.2"
 Sphinx = "^4.0.0"
 sphinx-rtd-theme = "^1.0.0"
 

--- a/setup.py
+++ b/setup.py
@@ -278,8 +278,6 @@ if __name__ == "__main__":
           classifiers=[
             'Operating System :: OS Independent',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.7',
-            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: Implementation :: CPython',
             'Programming Language :: Python :: Implementation :: PyPy',
             ('License :: OSI Approved :: '


### PR DESCRIPTION
Also remove the trove classifiers for specific Python versions.
Not sure if there is any point in maintinging that list given
it's already in the metadata.