### PR TITLE
Bump the buffer size a bit for resizing files

### DIFF
--- a/mutagen/_util.py
+++ b/mutagen/_util.py
@@ -24,7 +24,7 @@ from functools import wraps
 from fnmatch import fnmatchcase
 
 
-_DEFAULT_BUFFER_SIZE = 2 ** 18
+_DEFAULT_BUFFER_SIZE = 2 ** 20
 
 
 def endswith(text, end):


### PR DESCRIPTION
256KB was chosen as good enough when doing local copies, but in #553
it was pointed out that this is quite slow with remote filesystems like
NFS etc.

Bump to 1MB to improve that a bit..