### PR TITLE
Removed python 4 requirement as it does't exist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,7 @@ if __name__ == "__main__":
             ('share/man/man1', glob.glob("man/*.1")),
           ],
           python_requires=(
-            '>=3.7, <4'),
+            '>=3.7'),
           entry_points={
             'console_scripts': [
               'mid3cp=mutagen._tools.mid3cp:entry_point',


### PR DESCRIPTION
Removed python 4 requirements as it doesn't exist and won't be released in near future. So, we don't have to check if the version is lesser than version 4. greater than version 3.7 is enough. 