### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ sphinx-rtd-theme = "^1.0.0"
 sphinx-autobuild = "^2021.3.14"
 
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools"]
 
 [tool.coverage.run]
 include=["mutagen/*", "tests/*"]


### PR DESCRIPTION
Remove the redundant `wheel` dependency, as it is added by the backend automatically.  Listing it explicitly in the documentation was a historical mistake and has been fixed since, see: https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a