### PR TITLE
docs: Make extlinks compatible with sphinx 6.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,10 +26,10 @@ html_title = project
 exclude_patterns = ['_build']
 
 extlinks = {
-    'bug': ('https://github.com/quodlibet/mutagen/issues/%s', '#'),
-    'pr': ('https://github.com/quodlibet/mutagen/pull/%s', '#pr'),
-    'commit': ('https://github.com/quodlibet/mutagen/commit/%s', '#'),
-    'user': ('https://github.com/%s', ''),
+    'bug': ('https://github.com/quodlibet/mutagen/issues/%s', '#%s'),
+    'pr': ('https://github.com/quodlibet/mutagen/pull/%s', '#pr%s'),
+    'commit': ('https://github.com/quodlibet/mutagen/commit/%s', '%s'),
+    'user': ('https://github.com/%s', '%s'),
 }
 
 


### PR DESCRIPTION
The caption must contain `%s` exactly once¹ and because it did not building the docs using sphinx 6.0 failed.

```
mutagen> reading sources... [ 62%] changelog0mmm00m
mutagen> Exception occurred:
mutagen>   File "/nix/store/45b9bmcr6w6k05syyflc4r8j4gzzbjkm-python3.10-sphinx-6.0.0/lib/python3.10/site-packages/sphinx/ext/extlinks.py", line 101, in role
mutagen>     title = caption % part
mutagen> TypeError: not all arguments converted during string formatting
mutagen> The full traceback has been saved in /build/sphinx-err-kzqq6ki_.log, if you want to report the issue to the developers.
```

[1] https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html#confval-extlinks