### PR TITLE
Read the WAVE info attributes as unsigned short

### DIFF
--- a/mutagen/wave.py
+++ b/mutagen/wave.py
@@ -85,7 +85,7 @@ class WaveStreamInfo(StreamInfo):
         # RIFF: http://soundfile.sapp.org/doc/WaveFormat/
         #  Python struct.unpack:
         #    https://docs.python.org/2/library/struct.html#byte-order-size-and-alignment
-        info = struct.unpack('<hhLLhh', data[:self.SIZE])
+        info = struct.unpack('<HHLLHH', data[:self.SIZE])
         self.audio_format, self.channels, self.sample_rate, byte_rate, \
             block_align, self.bits_per_sample = info
         self.bitrate = self.channels * self.bits_per_sample * self.sample_rate


### PR DESCRIPTION
Microsoft defines these fields as WORD, which is usually unsigned. The audio format byte can take values like FFFE for extensible WAVE, which only makes sense if read unsigned.

Fixes #595