### PR TITLE
Allows TYER tags in the form of 'yyyy-mm-dd'

### DIFF
--- a/mutagen/id3/_tags.py
+++ b/mutagen/id3/_tags.py
@@ -366,17 +366,20 @@ class ID3Tags(DictProxy, Tags):
         # TDAT, TYER, and TIME have been turned into TDRC.
         timestamps = []
         old_frames = [self.pop(n, []) for n in ["TYER", "TDAT", "TIME"]]
-        for y, d, t in zip_longest(*old_frames, fillvalue=u""):
-            ym = re.match(r"([0-9]+)\Z", y)
-            dm = re.match(r"([0-9]{2})([0-9]{2})\Z", d)
-            tm = re.match(r"([0-9]{2})([0-9]{2})\Z", t)
+        for tyer, tdat, time in zip_longest(*old_frames, fillvalue=""):
+            ym = re.match(r"([0-9]{4})(-[0-9]{2}-[0-9]{2})?\Z", tyer)
+            dm = re.match(r"([0-9]{2})([0-9]{2})\Z", tdat)
+            tm = re.match(r"([0-9]{2})([0-9]{2})\Z", time)
             timestamp = ""
             if ym:
-                timestamp += u"%s" % ym.groups()
+                (year, month_day) = ym.groups()
+                timestamp += "%s" % year
                 if dm:
-                    timestamp += u"-%s-%s" % dm.groups()[::-1]
+                    month_day = "-%s-%s" % dm.groups()[::-1]
+                if month_day:
+                    timestamp += month_day
                     if tm:
-                        timestamp += u"T%s:%s:00" % tm.groups()
+                        timestamp += "T%s:%s:00" % tm.groups()
             if timestamp:
                 timestamps.append(timestamp)
         if timestamps and "TDRC" not in self:

--- a/tests/test_id3.py
+++ b/tests/test_id3.py
@@ -61,6 +61,21 @@ class TID3Read(TestCase):
         self.failIf("TYER" in audio)
         self.failUnless("TIT2" in audio)
 
+    def test_handle_tyer_full_date(self):
+        id3 = ID3()
+        id3.version = (2, 3)
+        id3.add(TYER(encoding=0, text="2022-02-14"))
+        id3.update_to_v24()
+        self.failUnlessEqual(id3["TDRC"], "2022-02-14")
+
+    def test_handle_tyer_full_date_with_tdat(self):
+        id3 = ID3()
+        id3.version = (2, 3)
+        id3.add(TYER(encoding=0, text="2022-02-14"))
+        id3.add(TDAT(encoding=0, text="0504"))
+        id3.update_to_v24()
+        self.failUnlessEqual(id3["TDRC"], "2022-04-05")
+
     def test_tdrc(self):
         tags = ID3()
         tags.add(id3.TDRC(encoding=1, text="2003-04-05 12:03"))


### PR DESCRIPTION
This is an alternative implementation to #529. It allows using `TYER` in non-standard `YYYY-mm-dd` format when upgrading ID3 v2.3 to v2.4. The difference to #529 is that this patch adds tests and also considers the `mm-dd` part in case there is no corresponding `TDAT` frame. This reduces data loss even further in case of non-standard use of `TYER`.