### PR TITLE
Fix typos

### DIFF
--- a/mutagen/_tools/mid3iconv.py
+++ b/mutagen/_tools/mid3iconv.py
@@ -6,7 +6,7 @@
 # (at your option) any later version.
 
 """
-ID3iconv is a Java based ID3 encoding convertor, here's the Python version.
+ID3iconv is a Java based ID3 encoding converter, here's the Python version.
 """
 
 import sys

--- a/mutagen/_util.py
+++ b/mutagen/_util.py
@@ -28,7 +28,7 @@ _DEFAULT_BUFFER_SIZE = 2 ** 20
 
 
 def endswith(text, end):
-    # usefull for paths which can be both, str and bytes
+    # useful for paths which can be both, str and bytes
     if isinstance(text, str):
         if not isinstance(end, str):
             end = end.decode("ascii")

--- a/mutagen/asf/_util.py
+++ b/mutagen/asf/_util.py
@@ -284,7 +284,7 @@ CODECS = {
     0xA10C: u"Media Foundation Spectrum Analyzer Output",
     0xA10D: u"GSM 6.10 (Full-Rate) Speech",
     0xA10E: u"GSM 6.20 (Half-Rate) Speech",
-    0xA10F: u"GSM 6.60 (Enchanced Full-Rate) Speech",
+    0xA10F: u"GSM 6.60 (Enhanced Full-Rate) Speech",
     0xA110: u"GSM 6.90 (Adaptive Multi-Rate) Speech",
     0xA111: u"GSM Adaptive Multi-Rate WideBand Speech",
     0xA112: u"Polycom G.722",

--- a/mutagen/flac.py
+++ b/mutagen/flac.py
@@ -387,7 +387,7 @@ class CueSheetTrack(object):
 
     For CD-DA, track_numbers must be 1-99, or 170 for the
     lead-out. Track_numbers must be unique within a cue sheet. There
-    must be atleast one index in every track except the lead-out track
+    must be at least one index in every track except the lead-out track
     which must have none.
 
     Attributes:

--- a/mutagen/id3/_frames.py
+++ b/mutagen/id3/_frames.py
@@ -832,7 +832,7 @@ class TSOC(TextFrame):
 
 
 class TSOP(TextFrame):
-    "Perfomer Sort Order key"
+    "Performer Sort Order key"
 
 
 class TSOT(TextFrame):
@@ -1110,7 +1110,7 @@ class SYLT(Frame):
 class COMM(TextFrame):
     """User comment.
 
-    User comment frames have a descrption, like TXXX, and also a three
+    User comment frames have a description, like TXXX, and also a three
     letter ISO language code in the 'lang' attribute.
     """
 
@@ -1895,7 +1895,7 @@ class TS2(TSO2):
 
 
 class TSP(TSOP):
-    "Perfomer Sort Order key"
+    "Performer Sort Order key"
 
 
 class TSC(TSOC):
@@ -1931,7 +1931,7 @@ class TOT(TOAL):
 
 
 class TOA(TOPE):
-    "Original Artist/Perfomer"
+    "Original Artist/Performer"
 
 
 class TOL(TOLY):
@@ -1995,7 +1995,7 @@ class STC(SYTC):
 
 
 class ULT(USLT):
-    "Unsychronised lyrics/text transcription"
+    "Unsynchronised lyrics/text transcription"
 
 
 class SLT(SYLT):

--- a/mutagen/id3/_specs.py
+++ b/mutagen/id3/_specs.py
@@ -540,7 +540,7 @@ class MultiSpec(Spec):
         spec = self.specs[0]
 
         # Merge single text spec multispecs only.
-        # (TimeStampSpec beeing the exception, but it's not a valid v2.3 frame)
+        # (TimeStampSpec being the exception, but it's not a valid v2.3 frame)
         if not isinstance(spec, EncodedTextSpec) or \
                 isinstance(spec, TimeStampSpec):
             return value

--- a/mutagen/mp4/__init__.py
+++ b/mutagen/mp4/__init__.py
@@ -247,7 +247,7 @@ def _item_sort_key(key, value):
     last = len(order)
     # If there's no key-based way to distinguish, order by length.
     # If there's still no way, go by string comparison on the
-    # values, so we at least have something determinstic.
+    # values, so we at least have something deterministic.
     return (order.get(key[:4], last), len(repr(value)), repr(value))
 
 

--- a/mutagen/ogg.py
+++ b/mutagen/ogg.py
@@ -429,7 +429,7 @@ class OggPage(object):
             new_data_end = offset + data_size
             offset_adjust += (data_size - old_page.size)
 
-        # Finally, if there's any discrepency in length, we need to
+        # Finally, if there's any discrepancy in length, we need to
         # renumber the pages for the logical stream.
         if len(old_pages) != len(new_pages):
             fileobj.seek(new_data_end, 0)

--- a/mutagen/smf.py
+++ b/mutagen/smf.py
@@ -32,12 +32,12 @@ def _var_int(data, offset=0):
 
 
 def _read_track(chunk):
-    """Retuns a list of midi events and tempo change events"""
+    """Returns a list of midi events and tempo change events"""
 
     TEMPO, MIDI = range(2)
 
     # Deviations: The running status should be reset on non midi events, but
-    # some files contain meta events inbetween.
+    # some files contain meta events in between.
     # TODO: Offset and time signature are not considered.
 
     tempos = []


### PR DESCRIPTION
Found via `codespell -L
hart,inout,mot,ot,fo,dne,als,missings,wors,tye,falso`