### PR TITLE
id3: handle negative extended header sizes

### DIFF
--- a/mutagen/id3/_tags.py
+++ b/mutagen/id3/_tags.py
@@ -108,6 +108,9 @@ class ID3Header(object):
                 # excludes itself."
                 extsize = struct.unpack('>L', extsize_data)[0]
 
+            if extsize < 0:
+                raise error("invalid extended header size")
+
             self._extdata = read_full(fileobj, extsize)
 
 

--- a/tests/test_id3.py
+++ b/tests/test_id3.py
@@ -454,6 +454,11 @@ class TID3Header(TestCase):
         header = ID3Header(fileobj)
         self.assertEquals(header._extdata, b'\x00\x00\x56\x78\x9a\xbc')
 
+    def test_negative_header_size(self):
+        fileobj = BytesIO(
+            b'ID3\x04B@\x00\x00\x00\x00\x00\x00\x00\x00')
+        self.failUnlessRaises(ID3Error, ID3Header, fileobj)
+
     def test_23(self):
         id3 = ID3(self.silence)
         self.assertEqual(id3.version, (2, 3, 0))


### PR DESCRIPTION
The extended header size is an integer, so can be negative. This leads to read_full() getting called with a negative size and failing with ValueError.

Handle this case explicitly and raise a proper mutagen exception instead.