### PR TITLE
id3 frames fix bad cast due to str.isdigit

### DIFF
--- a/mutagen/id3/_frames.py
+++ b/mutagen/id3/_frames.py
@@ -568,7 +568,7 @@ class TCON(TextFrame):
         genre_re = re.compile(r"((?:\((?P<id>[0-9]+|RX|CR)\))*)(?P<str>.+)?")
         for value in self.text:
             # 255 possible entries in id3v1
-            if value.isdigit() and int(value) < 256:
+            if value.isdecimal() and int(value) < 256:
                 try:
                     genres.append(self.GENRES[int(value)])
                 except IndexError:


### PR DESCRIPTION
Hi

There is a bug in which strings containing subscripted numbers will return True to str.isdigit, so then it tries to cast to int, which raises ValueError. The intended behavior would be closer to str.isdecimal, which will always be safe to cast, see:

```
>>> value = "⁶⁶⁶"

>>> value.isdigit()
True

>>> int(value)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid literal for int() with base 10: '⁶⁶⁶'

>>> value.isdecimal()
False
```