### PR TITLE
tak: raise in case there is no stream info block

### DIFF
--- a/mutagen/tak.py
+++ b/mutagen/tak.py
@@ -162,6 +162,7 @@ class TAKInfo(StreamInfo):
             raise TAKHeaderError("not a TAK file")
 
         bitreader = _LSBBitReader(fileobj)
+        found_stream_info = False
         while True:
             type = TAKMetadata(bitreader.bits(7))
             bitreader.skip(1)  # Unused
@@ -173,11 +174,15 @@ class TAKInfo(StreamInfo):
                 break
             elif type == TAKMetadata.STREAM_INFO:
                 self._parse_stream_info(bitreader, size)
+                found_stream_info = True
             elif type == TAKMetadata.ENCODER_INFO:
                 self._parse_encoder_info(bitreader, data_size)
 
             assert bitreader.is_aligned()
             fileobj.seek(pos + size)
+
+        if not found_stream_info:
+            raise TAKHeaderError("missing stream info")
 
         if self.sample_rate > 0:
             self.length = self.number_of_samples / float(self.sample_rate)

--- a/tests/test_tak.py
+++ b/tests/test_tak.py
@@ -1,5 +1,6 @@
 
 import os
+import io
 
 from mutagen.tak import TAK, TAKHeaderError
 from tests import TestCase, DATA_DIR
@@ -47,3 +48,7 @@ class TTAK(TestCase):
     def test_pprint(self):
         self.failUnless(self.tak_no_tags.pprint())
         self.failUnless(self.tak_tags.pprint())
+
+    def test_fuzz_only_end(self):
+        with self.assertRaises(TAKHeaderError):
+            TAK(io.BytesIO(b'tBaK\x00\x00\x00\x00'))


### PR DESCRIPTION
in case there is just an end block we would succeed with parsing but things would be in a half initalized state, for example failing when pprint() is called.

Make sure we find and parse a stream info block