### PR TITLE
ac3: fix calls to nonexisting methods

### DIFF
--- a/mutagen/ac3.py
+++ b/mutagen/ac3.py
@@ -219,7 +219,7 @@ class AC3Info(StreamInfo):
         if timecod2e:
             r.skip(14)  # Time Code Second Half
         if r.bits(1):  # Additional Bit Stream Information Exists
-            addbsil = r.bit(6)  # Additional Bit Stream Information Length
+            addbsil = r.bits(6)  # Additional Bit Stream Information Length
             r.skip((addbsil + 1) * 8)
 
     @staticmethod
@@ -270,7 +270,7 @@ class AC3Info(StreamInfo):
                 if r.bits(1):  # blkid
                     r.skip(6)  # frmsizecod
         if r.bits(1):  # Additional Bit Stream Information Exists
-            addbsil = r.bit(6)  # Additional Bit Stream Information Length
+            addbsil = r.bits(6)  # Additional Bit Stream Information Length
             r.skip((addbsil + 1) * 8)
 
     @staticmethod

--- a/tests/test_ac3.py
+++ b/tests/test_ac3.py
@@ -1,5 +1,6 @@
 
 import os
+import io
 
 from mutagen.ac3 import AC3, AC3Error
 
@@ -44,3 +45,7 @@ class TAC3(TestCase):
     def test_pprint(self):
         self.assertTrue("ac-3" in self.ac3.pprint())
         self.assertTrue("ec-3" in self.eac3.pprint())
+
+    def test_fuzz_extra_bitstream_info(self):
+        with self.assertRaises(AC3Error):
+            AC3(io.BytesIO(b'\x0bwII\x00\x00\xe3\xe3//'))


### PR DESCRIPTION
This would raise AttributeError when parsing the file. Fix the typo bit() -> bits()