### PR TITLE
Allow writing lists of bytes into M4A freeform tags

### DIFF
--- a/mutagen/mp4/__init__.py
+++ b/mutagen/mp4/__init__.py
@@ -820,10 +820,12 @@ class MP4Tags(DictProxy, Tags):
 
         encoded = []
         for v in value:
-            if not isinstance(v, str):
-                raise TypeError("%r not str" % v)
-
-            encoded.append(v.encode("utf-8"))
+            if isinstance(v, bytes):
+                encoded.append(v)
+            elif isinstance(v, str):
+                encoded.append(v.encode("utf-8"))
+            else:
+                raise TypeError("%r neither str or bytes" % v)
 
         return self.__render_data(key, 0, flags, encoded)
 


### PR DESCRIPTION
when i wanted to write the `----:com.apple.iTunes:ARTISTS` as a mutli-value tag, no matter what i tried, i got one of two errors:
if i used bytes, like for everything else, for example `[b'EDEN', b'Leah Kelly']`, it would tell me:
```
File "C:\Users\Nex\scoop\apps\python\current\Lib\site-packages\mutagen\mp4\__init__.py", line 825, in __render_text
    raise TypeError("%r not str" % v)
TypeError: b'EDEN' not str
```
even if i absolutely ensured it was a string all the way through my tagging code, it somehow got converted to bytes internally and threw this error, or a similar one, something along side `bare string with no encoding`. This small PR just allows the value to be already bytes, since it get's internally converted to bytes somewhere along the way.

i tested it by editing my local install of mutagen, and it writes tags correctly now.