### PR TITLE
Fix handling of albumartistsort as TSO2 and TXXX:ALBUMARTISTSORT in EasyID3

### DIFF
--- a/mutagen/easyid3.py
+++ b/mutagen/easyid3.py
@@ -530,7 +530,6 @@ for desc, key in {
     u"MusicBrainz Album Release Country": "releasecountry",
     u"MusicBrainz Disc Id": "musicbrainz_discid",
     u"ASIN": "asin",
-    u"ALBUMARTISTSORT": "albumartistsort",
     u"PERFORMER": "performer",
     u"BARCODE": "barcode",
     u"CATALOGNUMBER": "catalognumber",

--- a/tests/test_easyid3.py
+++ b/tests/test_easyid3.py
@@ -3,7 +3,7 @@ import os
 import pickle
 
 from mutagen import MutagenError
-from mutagen.id3 import ID3FileType, ID3, RVA2, CHAP, TDRC, CTOC
+from mutagen.id3 import ID3FileType, ID3, RVA2, CHAP, TDRC, CTOC, TSO2
 from mutagen.easyid3 import EasyID3, error as ID3Error
 
 from tests import TestCase, DATA_DIR, get_temp_copy
@@ -428,3 +428,9 @@ class TEasyID3(TestCase):
             self.id3.save(self.filename)
             id3 = EasyID3(self.filename)
             self.failUnlessEqual(id3[tag], [u"foo"])
+
+    def test_albumartistsort(self):
+        self.realid3.add(TSO2(text=u"someartist"))
+        self.id3.save(self.filename)
+        id3 = EasyID3(self.filename)
+        self.failUnlessEqual(id3["albumartistsort"], [u"someartist"])

--- a/tests/test_easyid3.py
+++ b/tests/test_easyid3.py
@@ -3,7 +3,7 @@ import os
 import pickle
 
 from mutagen import MutagenError
-from mutagen.id3 import ID3FileType, ID3, RVA2, CHAP, TDRC, CTOC, TSO2
+from mutagen.id3 import ID3FileType, ID3, RVA2, CHAP, TDRC, CTOC, TSO2, TXXX
 from mutagen.easyid3 import EasyID3, error as ID3Error
 
 from tests import TestCase, DATA_DIR, get_temp_copy
@@ -434,3 +434,39 @@ class TEasyID3(TestCase):
         self.id3.save(self.filename)
         id3 = EasyID3(self.filename)
         self.failUnlessEqual(id3["albumartistsort"], [u"someartist"])
+
+        self.id3["albumartistsort"] = [u"otherartist"]
+        self.assertEqual(self.realid3["TSO2"], [u"otherartist"])
+
+        del self.id3["albumartistsort"]
+        self.assertEqual(len(self.id3), 0)
+
+    def test_albumartistsort_from_TXXX(self):
+        self.realid3.add(TXXX(desc="ALBUMARTISTSORT", text=u"someartist"))
+        self.id3.save(self.filename)
+        id3 = EasyID3(self.filename)
+        self.failUnlessEqual(id3["albumartistsort"], [u"someartist"])
+
+        self.id3["albumartistsort"] = [u"otherartist"]
+        self.assertEqual(self.realid3["TSO2"], [u"otherartist"])
+
+        del self.id3["albumartistsort"]
+        self.assertEqual(len(self.id3), 0)
+
+    def test_albumartistsort_with_both_frames(self):
+        self.realid3.add(TSO2(text=u"someartist"))
+        self.realid3.add(TXXX(desc="ALBUMARTISTSORT", text=u"someotherartist"))
+        self.id3.save(self.filename)
+        id3 = EasyID3(self.filename)
+        self.failUnlessEqual(id3["albumartistsort"], [u"someartist"])
+        self.assertEqual(len(self.id3), 1)
+        self.assertEqual(len(self.realid3), 2)
+
+        self.id3["albumartistsort"] = [u"otherartist"]
+        self.assertEqual(self.realid3["TSO2"], [u"otherartist"])
+
+        del self.id3["albumartistsort"]
+        self.assertEqual(len(self.id3), 0)
+        self.assertEqual(len(self.realid3), 0)
+
+        self.failUnlessRaises(KeyError, self.id3.__delitem__, "albumartistsort")


### PR DESCRIPTION
albumartistsort is duplicated as a Text key in [easyid3.py#L492](https://github.com/quodlibet/mutagen/blob/main/mutagen/easyid3.py#L492) and as a TXXX key in [easyid3.py#L533](https://github.com/quodlibet/mutagen/blob/main/mutagen/easyid3.py#L533) thus replacing the previous registration.

Because of that, before this change, loading a file with EasyID3 that has a `TSO2` frame doesn't make it available by accessing `albumartistsort`.

Even if `TSO2` is not an official tag it seems to be generally supported, and since picard writes `TSO2` frames for "album artist sort order",  I think it's better to give priority to `TSO2` over `TXXX:ALBUMARTISTSORT`.

I also added a test that fails with the current code and runs successfully after the fix is applied to make sure it doesn't break in the future again.

Actually, we can't just remove `TXXX:ALBUMARTISTSORT` registration, since that would break reading such frames in files already written as that. So I've added a third commit that falls back to getting the `TXXX:ALBUMARTISTSORT` value  if `TSO2` isn't found, deletes both `TSO2` and `TXXX:ALBUMARTISTSORT` frames when deleting `albumartistsort` and added more tests for those cases.

I'm aware this third commit makes the code a bit more complex, but I've tried to make it as generic as possible just in case other fallback frames need to be added in the future for some other key.