### PR TITLE
mp3: don't fail on non-ascii lame header version flags

### DIFF
--- a/mutagen/mp3/_util.py
+++ b/mutagen/mp3/_util.py
@@ -304,8 +304,12 @@ class LAMEHeader(object):
         # (I have seen such a file)
         if (major, minor) < (3, 90) or (
                 (major, minor) == (3, 90) and data[-11:-10] == b"("):
-            flag = data.strip(b"\x00").rstrip().decode("ascii")
-            return (major, minor), u"%d.%d%s" % (major, minor, flag), False
+            flag = data.strip(b"\x00").rstrip()
+            try:
+                flag_string = flag.decode("ascii")
+            except UnicodeDecodeError:
+                flag_string = " (?)"
+            return (major, minor), u"%d.%d%s" % (major, minor, flag_string), False
 
         if len(data) < 11:
             raise LAMEError("Invalid version: too long")

--- a/tests/test_mp3.py
+++ b/tests/test_mp3.py
@@ -358,6 +358,7 @@ class TLAMEHeader(TestCase):
         self.assertEqual(parse(b"LAME3.80 "), (u"3.80", False))
         self.assertEqual(parse(b"LAME3.88 (beta)"), (u"3.88 (beta)", False))
         self.assertEqual(parse(b"LAME3.90 (alpha)"), (u"3.90 (alpha)", False))
+        self.assertEqual(parse(b"LAME3.80 (no-ascii-\xff)"), (u"3.80 (?)", False))
         self.assertEqual(parse(b"LAME3.90 "), (u"3.90.0+", True))
         self.assertEqual(parse(b"LAME3.96a"), (u"3.96 (alpha)", True))
         self.assertEqual(parse(b"LAME3.96b"), (u"3.96 (beta)", True))


### PR DESCRIPTION
See https://issues.oss-fuzz.com/issues/42523736

We could raise there, but we are already returning "?" for unknown flags down below, so just do the same here.