### PR TITLE
Add support for ID_MD5_CHECKSUM in WavPack files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, '3.10', 3.11, '3.12', '3.13', '3.14', 'pypy-3.9']
+        python-version: [3.9, '3.10', 3.11, '3.12', '3.13', '3.14', 'pypy-3.11']
         exclude:
-          # hangs
+          # too slow
           - os: macos-latest
-            python-version: pypy-3.9
+            python-version: pypy-3.11
           - os: windows-latest
-            python-version: pypy-3.9
+            python-version: pypy-3.11
         include:
           - os: ubuntu-latest
             pip-cache: ~/.cache/pip


### PR DESCRIPTION
Add support for retrieving the ID_MD5_CHECKSUM in WavPack files, much like retrieving the md5 for FLAC is supported (albeit for some reason no longer documented).