### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, '3.10', 3.11, '3.12', '3.13', '3.14', 'pypy-3.11']
+        python-version: ['3.10', 3.11, '3.12', '3.13', '3.14', 'pypy-3.11']
         exclude:
           # too slow
           - os: macos-latest
@@ -28,7 +28,7 @@ jobs:
             pip-cache: ~\AppData\Local\pip\Cache
             poetry-cache: ~\AppData\Local\pypoetry\Cache
           - os: ubuntu-latest
-            python-version: 3.9
+            python-version: 3.10
             build-docs: true
           - os: ubuntu-latest
             python-version: 3.12

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 ignore_missing_imports = True
 
 [mypy-setup]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 sphinx:
   configuration: docs/conf.py

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ It can read Xing headers to accurately calculate the bitrate and length of
 MP3s. ID3 and APEv2 tags can be edited regardless of audio format. It can also
 manipulate Ogg streams on an individual packet/page level.
 
-Mutagen works with Python 3.9+ (CPython and PyPy) on Linux, Windows and macOS,
+Mutagen works with Python 3.10+ (CPython and PyPy) on Linux, Windows and macOS,
 and has no dependencies outside the Python standard library. Mutagen is licensed
 under `the GPL version 2 or
 later <https://spdx.org/licenses/GPL-2.0-or-later.html>`__.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "read and write audio tags for many formats"
 readme = { file = "README.rst", content-type = "text/x-rst" }
 authors = [{ name = "Christoph Reiter", email = "reiter.christoph@gmail.com" }]
 license = "GPL-2.0-or-later"
-requires-python = ">=3.9, <4"
+requires-python = ">=3.10, <4"
 classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
it's EOL: https://peps.python.org/pep-0596