### PR TITLE
add typing to `mutagen.File`

### DIFF
--- a/mutagen/__init__.py
+++ b/mutagen/__init__.py
@@ -28,16 +28,12 @@ version = (1, 47, 1)
 version_string = ".".join(map(str, version))
 """Version string."""
 
-MutagenError
-
-FileType
-
-StreamInfo
-
-File
-
-Tags
-
-Metadata
-
-PaddingInfo
+__all__ = [
+    "MutagenError",
+    "FileType",
+    "StreamInfo",
+    "File",
+    "Tags",
+    "Metadata",
+    "PaddingInfo",
+]

--- a/mutagen/_file.py
+++ b/mutagen/_file.py
@@ -206,7 +206,7 @@ class StreamInfo(object):
 
 
 @loadfile(method=False)
-def File(filething, options=None, easy=False):
+def File(filething, options=None, easy=False) -> FileType | None:
     """File(filething, options=None, easy=False)
 
     Guess the type of the file and try to open it.
@@ -274,9 +274,8 @@ def File(filething, options=None, easy=False):
                    FLAC, AIFF, APEv2File, MP4, ID3FileType, WavPack,
                    Musepack, MonkeysAudio, OptimFROG, ASF, OggOpus, AAC, AC3,
                    SMF, TAK, DSF, DSDIFF, WAVE]
-
-    if not options:
-        return None
+    elif len(options) == 0:
+        raise ValueError("empty options given")
 
     fileobj = filething.fileobj
 


### PR DESCRIPTION
this is needed for py.typed libraries because
> Imported symbols are considered private by default.

ref: https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#library-interface

I tested locally and the types are detected ok
<img width="419" height="50" alt="image" src="https://github.com/user-attachments/assets/8d055f3c-57fa-4a16-a4e0-6744c765dbf8" />


fixes gh-647

edit: this now only include the typing to the signature of `mutagen.File` which I previously added