### PR TITLE
Add __all__ to  __init__.py

### DIFF
--- a/mutagen/__init__.py
+++ b/mutagen/__init__.py
@@ -36,4 +36,6 @@ __all__ = [
     "Tags",
     "Metadata",
     "PaddingInfo",
+    "version",
+    "version_string",
 ]


### PR DESCRIPTION
Addresses https://github.com/quodlibet/mutagen/issues/647. 

When using mypy in strict mode I am forced to import items from root mutagen namespace as:
```
from mutagen import File as MutagenFile  # type: ignore[attr-defined]
```
If I remove the ignore statement I get this error:
```
src/shares/indexer.py:12: error: Module "mutagen" does not explicitly export attribute "File"  [attr-defined]
```

There is another PR relating to this issue: https://github.com/quodlibet/mutagen/pull/695
But the tests are failing for that due to some changes made