### PR TITLE
mypy: enable no_implicit_reexport

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore=E128,W601,E402,E731,W503,E741,E305,E121,E124,W504
+ignore=E128,W601,E402,E731,W503,E741,E305,E121,E124,W504,F401
 exclude=build,dist,.venv
 max-line-length=88

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -4,6 +4,3 @@ ignore_missing_imports = True
 
 [mypy-setup]
 ignore_errors = True
-
-[mypy-tests.*]
-ignore_errors = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 python_version = 3.10
 ignore_missing_imports = True
+no_implicit_reexport = True
 
 [mypy-setup]
 ignore_errors = True

--- a/mutagen/dsdiff.py
+++ b/mutagen/dsdiff.py
@@ -17,7 +17,7 @@ from mutagen._iff import (
     IffID3,
     IffFile,
     InvalidChunk,
-    error as IffError,
+    error as _IffError,
 )
 from mutagen.id3._util import ID3NoHeaderError, error as ID3Error
 from mutagen._util import (
@@ -30,7 +30,7 @@ from mutagen._util import (
 __all__ = ["DSDIFF", "Open", "delete"]
 
 
-class error(IffError):
+class error(_IffError):
     pass
 
 

--- a/mutagen/easyid3.py
+++ b/mutagen/easyid3.py
@@ -17,7 +17,7 @@ import mutagen.id3
 
 from mutagen import Metadata
 from mutagen._util import DictMixin, dict_match, loadfile
-from mutagen.id3 import ID3, error, delete, ID3FileType
+from mutagen.id3 import ID3, error as error, delete, ID3FileType
 
 
 __all__ = ['EasyID3', 'Open', 'delete']

--- a/mutagen/id3/__init__.py
+++ b/mutagen/id3/__init__.py
@@ -29,59 +29,59 @@ Since this file's documentation is a little unwieldy, you are probably
 interested in the :class:`ID3` class to start with.
 """
 
-from ._file import ID3, ID3FileType, delete, ID3v1SaveOptions
-from ._specs import Encoding, PictureType, CTOCFlags, ID3TimeStamp
-from ._frames import Frames, Frames_2_2, Frame, TextFrame, UrlFrame, \
-    UrlFrameU, TimeStampTextFrame, BinaryFrame, NumericPartTextFrame, \
-    NumericTextFrame, PairedTextFrame
-from ._util import ID3NoHeaderError, error, ID3UnsupportedVersionError
-from ._id3v1 import ParseID3v1, MakeID3v1
-from ._tags import ID3Tags
-from ._frames import (AENC, APIC, ASPI, BUF, CHAP, CNT, COM, COMM, COMR, CRA,
-    CRM, CTOC, ENCR, EQU2, ETC, ETCO, GEO, GEOB, GP1, GRID, GRP1, IPL, IPLS,
-    LINK, LNK, MCDI, MCI, MLL, MLLT, MVI, MVIN, MVN, MVNM, OWNE, PCNT, PCST,
-    PIC, POP, POPM, POSS, PRIV, RBUF, REV, RVA, RVA2, RVAD, RVRB, SEEK, SIGN,
-    SLT, STC, SYLT, SYTC, TAL, TALB, TBP, TBPM, TCAT, TCM, TCMP, TCO, TCOM,
-    TCON, TCOP, TCP, TCR, TDA, TDAT, TDEN, TDES, TDLY, TDOR, TDRC, TDRL, TDTG,
-    TDY, TEN, TENC, TEXT, TFLT, TFT, TGID, TIM, TIME, TIPL, TIT1, TIT2, TIT3,
-    TKE, TKEY, TKWD, TLA, TLAN, TLE, TLEN, TMCL, TMED, TMOO, TMT, TOA, TOAL,
-    TOF, TOFN, TOL, TOLY, TOPE, TOR, TORY, TOT, TOWN, TP1, TP2, TP3, TP4, TPA,
-    TPB, TPE1, TPE2, TPE3, TPE4, TPOS, TPRO, TPUB, TRC, TRCK, TRD, TRDA, TRK,
-    TRSN, TRSO, TS2, TSA, TSC, TSI, TSIZ, TSO2, TSOA, TSOC, TSOP, TSOT, TSP,
-    TSRC, TSS, TSSE, TSST, TST, TT1, TT2, TT3, TXT, TXX, TXXX, TYE, TYER, UFI,
-    UFID, ULT, USER, USLT, WAF, WAR, WAS, WCM, WCOM, WCOP, WCP, WFED, WOAF,
-    WOAR, WOAS, WORS, WPAY, WPB, WPUB, WXX, WXXX)
+from ._file import ID3, ID3FileType, delete, ID3v1SaveOptions as ID3v1SaveOptions
+from ._specs import Encoding as Encoding, PictureType as PictureType, \
+    CTOCFlags as CTOCFlags, ID3TimeStamp as ID3TimeStamp
+from ._frames import Frames, Frames_2_2 as Frames_2_2, Frame as Frame, \
+    TextFrame as TextFrame, UrlFrame as UrlFrame, UrlFrameU as UrlFrameU, \
+    TimeStampTextFrame as TimeStampTextFrame, BinaryFrame as BinaryFrame, \
+    NumericPartTextFrame as NumericPartTextFrame, \
+    NumericTextFrame as NumericTextFrame, PairedTextFrame as PairedTextFrame
+from ._util import ID3NoHeaderError as ID3NoHeaderError, error as error, \
+    ID3UnsupportedVersionError as ID3UnsupportedVersionError
+from ._id3v1 import ParseID3v1 as ParseID3v1, MakeID3v1 as MakeID3v1
+from ._tags import ID3Tags as ID3Tags
+from ._frames import AENC as AENC, APIC as APIC, ASPI as ASPI, BUF as BUF, \
+    CHAP as CHAP, CNT as CNT, COM as COM, COMM as COMM, COMR as COMR, \
+    CRA as CRA, CRM as CRM, CTOC as CTOC, ENCR as ENCR, EQU2 as EQU2, \
+    ETC as ETC, ETCO as ETCO, GEO as GEO, GEOB as GEOB, GP1 as GP1, \
+    GRID as GRID, GRP1 as GRP1, IPL as IPL, IPLS as IPLS, LINK as LINK, \
+    LNK as LNK, MCDI as MCDI, MCI as MCI, MLL as MLL, MLLT as MLLT, MVI as MVI, \
+    MVIN as MVIN, MVN as MVN, MVNM as MVNM, OWNE as OWNE, PCNT as PCNT, \
+    PCST as PCST, PIC as PIC, POP as POP, POPM as POPM, \
+    POSS as POSS, PRIV as PRIV, RBUF as RBUF, REV as REV, RVA as RVA, RVA2 as RVA2, \
+    RVAD as RVAD, RVRB as RVRB, SEEK as SEEK, SIGN as SIGN, SLT as SLT, STC as STC, \
+    SYLT as SYLT, SYTC as SYTC, TAL as TAL, TALB as TALB, TBP as TBP, TBPM as TBPM, \
+    TCAT as TCAT, TCM as TCM, TCMP as TCMP, TCO as TCO, TCOM as TCOM, TCON as TCON, \
+    TCOP as TCOP, TCP as TCP, TCR as TCR, TDA as TDA, TDAT as TDAT, TDEN as TDEN, \
+    TDES as TDES, TDLY as TDLY, TDOR as TDOR, TDRC as TDRC, TDRL as TDRL, \
+    TDTG as TDTG, TDY as TDY, TEN as TEN, TENC as TENC, TEXT as TEXT, TFLT as TFLT, \
+    TFT as TFT, TGID as TGID, TIM as TIM, TIME as TIME, TIPL as TIPL, TIT1 as TIT1, \
+    TIT2 as TIT2, TIT3 as TIT3, TKE as TKE, TKEY as TKEY, TKWD as TKWD, TLA as TLA, \
+    TLAN as TLAN, TLE as TLE, TLEN as TLEN, TMCL as TMCL, TMED as TMED, \
+    TMOO as TMOO, TMT as TMT, TOA as TOA, TOAL as TOAL, TOF as TOF, TOFN as TOFN, \
+    TOL as TOL, TOLY as TOLY, TOPE as TOPE, TOR as TOR, TORY as TORY, TOT as TOT, \
+    TOWN as TOWN, TP1 as TP1, TP2 as TP2, TP3 as TP3, TP4 as TP4, TPA as TPA, \
+    TPB as TPB, TPE1 as TPE1, TPE2 as TPE2, TPE3 as TPE3, TPE4 as TPE4, \
+    TPOS as TPOS, TPRO as TPRO, TPUB as TPUB, TRC as TRC, TRCK as TRCK, TRD as TRD, \
+    TRDA as TRDA, TRK as TRK, TRSN as TRSN, TRSO as TRSO, TS2 as TS2, TSA as TSA, \
+    TSC as TSC, TSI as TSI, TSIZ as TSIZ, TSO2 as TSO2, TSOA as TSOA, TSOC as TSOC, \
+    TSOP as TSOP, TSOT as TSOT, TSP as TSP, TSRC as TSRC, TSS as TSS, TSSE as TSSE, \
+    TSST as TSST, TST as TST, TT1 as TT1, TT2 as TT2, TT3 as TT3, TXT as TXT, \
+    TXX as TXX, TXXX as TXXX, TYE as TYE, TYER as TYER, UFI as UFI, UFID as UFID, \
+    ULT as ULT, USER as USER, USLT as USLT, WAF as WAF, WAR as WAR, WAS as WAS, \
+    WCM as WCM, WCOM as WCOM, WCOP as WCOP, WCP as WCP, WFED as WFED, WOAF as WOAF, \
+    WOAR as WOAR, WOAS as WOAS, WORS as WORS, WPAY as WPAY, WPB as WPB, WPUB as WPUB, \
+    WXX as WXX, WXXX as WXXX
 
 # deprecated
-from ._util import ID3EncryptionUnsupportedError, ID3JunkFrameError, \
-    ID3BadUnsynchData, ID3BadCompressedData, ID3TagError, ID3Warning, \
-    BitPaddedInt as _BitPaddedIntForPicard
+from ._util import ID3EncryptionUnsupportedError as ID3EncryptionUnsupportedError, \
+    ID3JunkFrameError as ID3JunkFrameError, ID3BadUnsynchData as ID3BadUnsynchData, \
+    ID3BadCompressedData as ID3BadCompressedData, ID3TagError as ID3TagError, \
+    ID3Warning as ID3Warning, BitPaddedInt as _BitPaddedIntForPicard
 
 # support open(filename) as interface
 Open = ID3
-
-# flake8
-ID3, ID3FileType, delete, ID3v1SaveOptions, Encoding, PictureType, CTOCFlags,
-ID3TimeStamp, Frames, Frames_2_2, Frame, TextFrame, UrlFrame, UrlFrameU,
-TimeStampTextFrame, BinaryFrame, NumericPartTextFrame, NumericTextFrame,
-PairedTextFrame, ID3NoHeaderError, error, ID3UnsupportedVersionError,
-ParseID3v1, MakeID3v1, ID3Tags, ID3EncryptionUnsupportedError,
-ID3JunkFrameError, ID3BadUnsynchData, ID3BadCompressedData, ID3TagError,
-ID3Warning
-
-AENC, APIC, ASPI, BUF, CHAP, CNT, COM, COMM, COMR, CRA, CRM, CTOC, ENCR, EQU2,
-ETC, ETCO, GEO, GEOB, GP1, GRID, GRP1, IPL, IPLS, LINK, LNK, MCDI, MCI, MLL,
-MLLT, MVI, MVIN, MVN, MVNM, OWNE, PCNT, PCST, PIC, POP, POPM, POSS, PRIV,
-RBUF, REV, RVA, RVA2, RVAD, RVRB, SEEK, SIGN, SLT, STC, SYLT, SYTC, TAL, TALB,
-TBP, TBPM, TCAT, TCM, TCMP, TCO, TCOM, TCON, TCOP, TCP, TCR, TDA, TDAT, TDEN,
-TDES, TDLY, TDOR, TDRC, TDRL, TDTG, TDY, TEN, TENC, TEXT, TFLT, TFT, TGID,
-TIM, TIME, TIPL, TIT1, TIT2, TIT3, TKE, TKEY, TKWD, TLA, TLAN, TLE, TLEN,
-TMCL, TMED, TMOO, TMT, TOA, TOAL, TOF, TOFN, TOL, TOLY, TOPE, TOR, TORY, TOT,
-TOWN, TP1, TP2, TP3, TP4, TPA, TPB, TPE1, TPE2, TPE3, TPE4, TPOS, TPRO, TPUB,
-TRC, TRCK, TRD, TRDA, TRK, TRSN, TRSO, TS2, TSA, TSC, TSI, TSIZ, TSO2, TSOA,
-TSOC, TSOP, TSOT, TSP, TSRC, TSS, TSSE, TSST, TST, TT1, TT2, TT3, TXT, TXX,
-TXXX, TYE, TYER, UFI, UFID, ULT, USER, USLT, WAF, WAR, WAS, WCM, WCOM, WCOP,
-WCP, WFED, WOAF, WOAR, WOAS, WORS, WPAY, WPB, WPUB, WXX, WXXX
 
 
 # Workaround for http://tickets.musicbrainz.org/browse/PICARD-833

--- a/mutagen/id3/_file.py
+++ b/mutagen/id3/_file.py
@@ -16,7 +16,8 @@ from mutagen._tags import PaddingInfo
 
 from ._util import error, ID3NoHeaderError, ID3UnsupportedVersionError, \
     BitPaddedInt
-from ._tags import ID3Tags, ID3Header, ID3SaveConfig
+from ._util import ID3SaveConfig
+from ._tags import ID3Tags, ID3Header
 from ._id3v1 import MakeID3v1, find_id3v1
 
 

--- a/mutagen/wave.py
+++ b/mutagen/wave.py
@@ -14,8 +14,8 @@ import struct
 from mutagen import StreamInfo, FileType
 
 from mutagen.id3 import ID3
-from mutagen._riff import RiffFile, InvalidChunk
-from mutagen._iff import error as IffError
+from mutagen._riff import RiffFile
+from mutagen._iff import error as _IffError, InvalidChunk
 from mutagen.id3._util import ID3NoHeaderError, error as ID3Error
 from mutagen._util import (
     convert_error,
@@ -27,7 +27,7 @@ from mutagen._util import (
 __all__ = ["WAVE", "Open", "delete"]
 
 
-class error(IffError):
+class error(_IffError):
     """WAVE stream parsing errors."""
 
 

--- a/mutagen/wavpack.py
+++ b/mutagen/wavpack.py
@@ -19,7 +19,7 @@ for more information.
 __all__ = ["WavPack", "Open", "delete"]
 
 from mutagen import StreamInfo
-from mutagen.apev2 import APEv2File, error, delete
+from mutagen.apev2 import APEv2File, error as error, delete
 from mutagen._util import cdata, convert_error
 
 

--- a/tests/test__id3specs.py
+++ b/tests/test__id3specs.py
@@ -6,7 +6,8 @@ from mutagen.id3._specs import SpecError, Latin1TextListSpec, ID3FramesSpec, \
     EncodedTextSpec, VolumePeakSpec, VolumeAdjustmentSpec, CTOCFlagsSpec, \
     Spec, SynchronizedTextSpec, TimeStampSpec, FrameIDSpec, RVASpec
 from mutagen.id3._frames import Frame
-from mutagen.id3._tags import ID3Header, ID3Tags, ID3SaveConfig
+from mutagen.id3._tags import ID3Header, ID3Tags
+from mutagen.id3._util import ID3SaveConfig
 from mutagen.id3 import TIT3, ASPI, CTOCFlags, ID3TimeStamp
 
 

--- a/tests/test__util.py
+++ b/tests/test__util.py
@@ -12,10 +12,6 @@ import errno
 import builtins
 from io import BytesIO
 
-try:
-    import fcntl
-except ImportError:
-    fcntl = None
 
 import pytest
 

--- a/tests/test_apev2.py
+++ b/tests/test_apev2.py
@@ -293,7 +293,6 @@ class TAPEv2WithLyrics2(TestCase):
 class TAPEBinaryValue(TestCase):
 
     from mutagen.apev2 import APEBinaryValue as BV
-    BV = BV
 
     def setUp(self):
         self.sample = b"\x12\x45\xde"
@@ -319,7 +318,6 @@ class TAPEBinaryValue(TestCase):
 class TAPETextValue(TestCase):
 
     from mutagen.apev2 import APETextValue as TV
-    TV = TV
 
     def setUp(self):
         self.sample = ["foo", "bar", "baz"]
@@ -378,7 +376,6 @@ class TAPETextValue(TestCase):
 class TAPEExtValue(TestCase):
 
     from mutagen.apev2 import APEExtValue as EV
-    EV = EV
 
     def setUp(self):
         self.sample = "http://foo"

--- a/tests/test_asf.py
+++ b/tests/test_asf.py
@@ -3,14 +3,14 @@ import os
 import warnings
 from io import BytesIO
 
-from mutagen.asf import ASF, ASFHeaderError, ASFValue, UNICODE, DWORD, QWORD
+from mutagen.asf import ASF, UNICODE, DWORD, QWORD
 from mutagen.asf import BOOL, WORD, BYTEARRAY, GUID
-from mutagen.asf._util import guid2bytes, bytes2guid
+from mutagen.asf._util import guid2bytes, bytes2guid, ASFHeaderError, ASFError
 from mutagen.asf._objects import ContentDescriptionObject, \
     ExtendedContentDescriptionObject, HeaderExtensionObject, \
     MetadataObject, MetadataLibraryObject, CodecListObject, PaddingObject, \
     HeaderObject
-from mutagen.asf import ASFUnicodeAttribute, ASFError, ASFByteArrayAttribute, \
+from mutagen.asf._attrs import ASFValue, ASFUnicodeAttribute, ASFByteArrayAttribute, \
     ASFBoolAttribute, ASFDWordAttribute, ASFQWordAttribute, ASFWordAttribute, \
     ASFGUIDAttribute
 

--- a/tests/test_dsdiff.py
+++ b/tests/test_dsdiff.py
@@ -1,7 +1,8 @@
 
 import os
 
-from mutagen.dsdiff import DSDIFF, IffError
+from mutagen.dsdiff import DSDIFF
+from mutagen._iff import error
 
 from tests import TestCase, DATA_DIR, get_temp_copy
 
@@ -43,7 +44,7 @@ class TDSDIFF(TestCase):
         self.failUnlessEqual(self.dff_dst.info.bitrate, 0)
 
     def test_notdsf(self):
-        self.failUnlessRaises(IffError, DSDIFF, os.path.join(
+        self.failUnlessRaises(error, DSDIFF, os.path.join(
             DATA_DIR, '2822400-1ch-0s-silence.dsf'))
 
     def test_pprint(self):

--- a/tests/test_flac.py
+++ b/tests/test_flac.py
@@ -8,9 +8,10 @@ from mutagen import MutagenError
 from mutagen.id3 import ID3, TIT2, ID3NoHeaderError
 from mutagen.flac import to_int_be, Padding, VCFLACDict, MetadataBlock, error
 from mutagen.flac import StreamInfo, SeekTable, CueSheet, FLAC, delete, Picture
+from mutagen._vorbis import VComment
 
 from tests import TestCase, DATA_DIR, get_temp_copy
-from tests.test__vorbis import TVCommentDict, VComment
+from tests.test__vorbis import TVCommentDict
 
 
 def call_flac(*args):

--- a/tests/test_id3.py
+++ b/tests/test_id3.py
@@ -10,9 +10,8 @@ from mutagen.id3 import ID3, Frames, ID3UnsupportedVersionError, TIT2, \
     TDAT, TIME, LNK, IPLS, TPE1, BinaryFrame, TIT3, POPM, APIC, CRM, \
     TALB, TPE2, TSOT, TDEN, TIPL, ParseID3v1, Encoding, ID3Tags, RVAD, \
     ID3NoHeaderError, Frames_2_2
-from mutagen.id3._util import BitPaddedInt, error as ID3Error
-from mutagen.id3._tags import determine_bpi, ID3Header, \
-    save_frame, ID3SaveConfig
+from mutagen.id3._util import BitPaddedInt, error as ID3Error, ID3SaveConfig
+from mutagen.id3._tags import determine_bpi, ID3Header, save_frame
 from mutagen.id3._id3v1 import find_id3v1
 
 from tests import TestCase, DATA_DIR, get_temp_copy, get_temp_empty

--- a/tests/test_mp4.py
+++ b/tests/test_mp4.py
@@ -7,9 +7,10 @@ from io import BytesIO
 import pytest
 
 from tests import TestCase, DATA_DIR, get_temp_copy
-from mutagen.mp4 import (MP4, Atom, Atoms, MP4Tags, MP4Info, delete, MP4Cover,
+from mutagen.mp4 import (MP4, MP4Tags, MP4Info, delete, MP4Cover,
                          MP4MetadataError, MP4FreeForm, error, AtomDataType,
-                         AtomError, _item_sort_key, MP4StreamInfoError)
+                         _item_sort_key, MP4StreamInfoError)
+from mutagen.mp4._atom import Atom, Atoms, AtomError
 from mutagen.mp4._util import parse_full_atom
 from mutagen.mp4._as_entry import AudioSampleEntry, ASEntryError
 from mutagen._util import cdata

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,7 +13,7 @@ def get_var(tool_name, entry="main"):
 
 
 class _TTools(TestCase):
-    TOOL_NAME = None
+    TOOL_NAME: str | None = None
 
     def setUp(self):
         self.assertTrue(isinstance(self.TOOL_NAME, str))

--- a/tests/test_wave.py
+++ b/tests/test_wave.py
@@ -1,7 +1,8 @@
 
 import os
 
-from mutagen.wave import WAVE, InvalidChunk
+from mutagen.wave import WAVE
+from mutagen._iff import InvalidChunk
 from tests import TestCase, DATA_DIR, get_temp_copy
 
 


### PR DESCRIPTION
Either explicitely "re-export" (I whish there was a nicer way, as renaming
also falls under this) or change the imports to import from the source.

flake8 doesn't understand this, so just disable the warning of unused vars
there. Maybe ruff will be smarter there.

Fixes https://github.com/quodlibet/mutagen/issues/699