### PR TITLE
id3v1: save comment when COMM frame is stored under its HashKey

### DIFF
--- a/mutagen/id3/_id3v1.py
+++ b/mutagen/id3/_id3v1.py
@@ -172,10 +172,14 @@ def MakeID3v1(id3):
             text = b""
         v1[name] = text + (b"\x00" * (30 - len(text)))
 
+    cmnt = b""
     if "COMM" in id3:
         cmnt = id3["COMM"].text[0].encode('latin1', 'replace')[:28]
     else:
-        cmnt = b""
+        for key, frame in id3.items():
+            if key.startswith("COMM:"):
+                cmnt = frame.text[0].encode('latin1', 'replace')[:28]
+                break
     v1["comment"] = cmnt + (b"\x00" * (29 - len(cmnt)))
 
     if "TRCK" in id3:

--- a/tests/test_id3.py
+++ b/tests/test_id3.py
@@ -690,6 +690,12 @@ class ID3v1Tags(TestCase):
         v1tag = MakeID3v1(tag)
         self.failUnlessEqual(ParseID3v1(v1tag)["TCON"].genres, ["Pop"])
 
+    def test_make_comm_from_hashkey(self):
+        frame = COMM(encoding=0, lang="eng",
+                     desc="ID3v1 Comment", text="hello")
+        tag = {frame.HashKey: frame}
+        self.failUnlessEqual(ParseID3v1(MakeID3v1(tag))["COMM"], "hello")
+
 
 class TestWriteID3v1(TestCase):
 


### PR DESCRIPTION
COMM frames are stored in ID3Tags under their HashKey (`COMM:desc:lang`), so `MakeID3v1` never finds them via the bare `COMM` key and the comment is dropped from the resulting ID3v1 tag. Fall back to scanning for a `COMM:`-prefixed entry when no plain `COMM` key exists.

Closes #660