### PR TITLE
wavpack: use WavPackHeaderError in tests, avoid re-export import

### DIFF
--- a/mutagen/wavpack.py
+++ b/mutagen/wavpack.py
@@ -19,7 +19,7 @@ for more information.
 __all__ = ["WavPack", "Open", "delete"]
 
 from mutagen import StreamInfo
-from mutagen.apev2 import APEv2File, error as error, delete
+from mutagen.apev2 import APEv2File, error, delete
 from mutagen._util import cdata, convert_error
 
 

--- a/tests/test_wavpack.py
+++ b/tests/test_wavpack.py
@@ -1,7 +1,7 @@
 
 import os
 
-from mutagen.wavpack import WavPack, error as WavPackError
+from mutagen.wavpack import WavPack, WavPackHeaderError
 from tests import TestCase, DATA_DIR
 
 
@@ -27,7 +27,7 @@ class TWavPack(TestCase):
 
     def test_not_my_file(self):
         self.failUnlessRaises(
-            WavPackError, WavPack, os.path.join(DATA_DIR, "empty.ogg"))
+            WavPackHeaderError, WavPack, os.path.join(DATA_DIR, "empty.ogg"))
 
     def test_pprint(self):
         self.audio.pprint()


### PR DESCRIPTION
A small change over https://github.com/quodlibet/mutagen/pull/702 regarding my comments on the wavpack error export. I think this specific case we don't need to re-export and can handle in the affected test.