### PR TITLE
_util: make DictMixin unhashable to fix hash/equality contract violation

### DIFF
--- a/mutagen/_util.py
+++ b/mutagen/_util.py
@@ -522,7 +522,11 @@ class DictMixin(object):
     def __lt__(self, other):
         return dict(self.items()) < other
 
-    __hash__ = object.__hash__
+    # DictMixin overrides __eq__ with content comparison, so objects with
+    # equal content but different identities would compare equal but hash
+    # differently when using object.__hash__. Since these tag objects are
+    # mutable, make them explicitly unhashable (like Python's built-in dict).
+    __hash__ = None  # type: ignore[assignment]
 
     def __len__(self):
         return len(self.keys())

--- a/tests/test__util.py
+++ b/tests/test__util.py
@@ -123,6 +123,12 @@ class TDictMixin(TestCase):
     def test_len(self):
         self.failUnlessEqual(len(self.rdict), len(self.fdict))
 
+    def test_unhashable(self):
+        # DictMixin defines __eq__ by content, so objects with equal content
+        # would hash differently under object.__hash__ (identity).  The class
+        # must be unhashable to respect Python's hash/equality invariant.
+        self.failUnlessRaises(TypeError, hash, self.fdict)
+
     def tearDown(self):
         self.failUnlessEqual(self.fdict, self.rdict)
         self.failUnlessEqual(self.rdict, self.fdict)


### PR DESCRIPTION
Fixes #603.

## Problem

`DictMixin.__eq__` compares objects by their tag content:

```python
def __eq__(self, other):
    return dict(self.items()) == other
```

But `__hash__` was set to `object.__hash__`, which is identity-based. This violates Python's fundamental requirement that **objects which compare equal must have the same hash value**:

```python
from mutagen.flac import FLAC
f1 = FLAC("test.flac")
f2 = FLAC("test.flac")
assert f1 == f2          # True — same tags
assert hash(f1) == hash(f2)  # False — broken!
```

Any code that puts FLAC (or other tag) objects into sets, uses them as dict keys, or relies on the hash/equality contract is silently broken.

## Fix

Set `__hash__ = None` in `DictMixin`, making instances explicitly unhashable — consistent with Python's own mutable `dict`. All `DictMixin` subclasses (tag types, file types) are mutable mappings, so unhashability is the correct behavior.

## Testing

Added a regression test in `TDictMixin.test_unhashable`. Full suite (3993 tests) passes.

---
This pull request was prepared with the assistance of AI, under my direction and review.