### PR TITLE
FLAC: read tags from a later VORBIS_COMMENT block if the first is empty

### DIFF
--- a/mutagen/flac.py
+++ b/mutagen/flac.py
@@ -732,6 +732,13 @@ class FLAC(mutagen.FileType):
         if block.code == VCFLACDict.code:
             if self.tags is None:
                 self.tags = block
+            elif not self.tags:
+                # https://github.com/quodlibet/mutagen/issues/692
+                # Some files have an empty first VORBIS_COMMENT block
+                # followed by a populated one; prefer the populated block,
+                # as FFmpeg and the reference implementation do.
+                self.metadata_blocks.remove(self.tags)
+                self.tags = block
             else:
                 # https://github.com/quodlibet/mutagen/issues/377
                 # Something writes multiple and metaflac doesn't care

--- a/tests/test_flac.py
+++ b/tests/test_flac.py
@@ -339,6 +339,30 @@ class TFLAC(TestCase):
         self.assertEqual(num_padding(new), 1)
         self.assertTrue(isinstance(new.metadata_blocks[-1], Padding))
 
+    def test_empty_vorbiscomment_before_populated(self):
+        # https://github.com/quodlibet/mutagen/issues/692
+        # An empty VORBIS_COMMENT block before a populated one must not hide
+        # the tags in the populated block (FFmpeg and the reference
+        # implementation read the populated block in this case).
+        self.flac["title"] = [u"A Title"]
+        self.flac.save()
+
+        # inject an empty VORBIS_COMMENT block before the populated one
+        f = FLAC(self.NEW)
+        populated = f.tags
+        assert populated
+        f.metadata_blocks.insert(
+            f.metadata_blocks.index(populated), VCFLACDict())
+        f.save()
+
+        f = FLAC(self.NEW)
+        assert f.tags
+        assert f["title"] == [u"A Title"]
+        # the empty leading block is dropped, leaving a single comment block
+        vc_blocks = [b for b in f.metadata_blocks
+                     if b.code == VCFLACDict.code]
+        assert len(vc_blocks) == 1
+
     def test_increase_size_new_padding(self):
         self.assertEqual(self.flac.metadata_blocks[-1].length, 3060)
         value = u"foo" * 100


### PR DESCRIPTION
Closes #692.

Some FLAC files in the wild contain an empty first VORBIS_COMMENT block followed by a populated one (the issue has a sample file). mutagen kept the first block and discarded the rest (per #377), so these files read as having no tags, while FFmpeg, metaflac, and macOS read the populated block.

This changes the load logic: when the current comment block is empty and a later VORBIS_COMMENT block is found, the populated block is preferred and the empty leading block is dropped (leaving a single, spec-compliant comment block on re-save). Files with a single block, or a populated first block followed by extras, are unaffected (#377 behaviour preserved).

Added a regression test that injects an empty VORBIS_COMMENT block before a populated one and checks the tags are read; it fails on `main` and passes with this change. Full `tests/test_flac.py` passes and `flake8` is clean.

Happy to add a NEWS entry if you'd like; I left it out since I didn't have a PR number to reference yet.